### PR TITLE
Guard hosted MCP mailbox targeting by surface

### DIFF
--- a/packages/python/tests/test_mcp.py
+++ b/packages/python/tests/test_mcp.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from typing import Any
 
 import httpx
@@ -8,8 +9,15 @@ import pytest
 from fastmcp import Client
 
 from sendmux_mcp.cli import parser, surfaces_from_args
-from sendmux_mcp.config import RetryConfig, ServerConfig
+from sendmux_mcp.config import RetryConfig, ServerConfig, Surface
 from sendmux_mcp.curation import TOOLS_BY_SURFACE
+from sendmux_mcp.hosted_proxy import (
+    HostedOperationManifest,
+    HostedOperationRoute,
+    HostedProxyConfig,
+    HostedProxyTransport,
+    path_template_pattern,
+)
 from sendmux_mcp.security import middleware_for_config
 from sendmux_mcp.server import create_server
 from sendmux_mcp.verification import structured_result
@@ -238,8 +246,78 @@ def test_http_security_middleware_blocks_unauthorised_mcp_requests() -> None:
     asyncio.run(check())
 
 
+def test_hosted_proxy_only_targets_mailbox_for_mailbox_surface() -> None:
+    transport = HostedProxyTransport(
+        HostedProxyConfig(
+            proxy_url="https://mcp.sendmux.ai/internal/proxy",
+            upstream_base_url="https://app.sendmux.ai/api/v1",
+        ),
+        manifest=HostedOperationManifest(()),
+    )
+    management_route = hosted_route("managementListMailboxes", "management_list_mailboxes", "management", "/mailboxes")
+    sending_route = hosted_route("sendingSendEmail", "sending_send_email", "sending", "/emails/send", method="POST")
+    mailbox_route = hosted_route("mailboxGetIdentity", "mailbox_get_identity", "mailbox", "/mailbox/identities/{public_id}")
+
+    management = proxy_envelope(
+        transport,
+        httpx.Request("GET", "https://app.sendmux.ai/api/v1/mailboxes?mailbox_id=mbx_one"),
+        management_route,
+    )
+    sending = proxy_envelope(
+        transport,
+        httpx.Request("POST", "https://smtp.sendmux.ai/api/v1/emails/send?mailbox_id=mbx_one"),
+        sending_route,
+    )
+    mailbox = proxy_envelope(
+        transport,
+        httpx.Request("GET", "https://app.sendmux.ai/api/v1/mailbox/identities/ident_1?mailbox_id=mbx_one"),
+        mailbox_route,
+    )
+
+    assert management["surface"] == "management"
+    assert "mailbox_id" not in management
+    assert sending["surface"] == "sending"
+    assert "mailbox_id" not in sending
+    assert mailbox["surface"] == "mailbox"
+    assert mailbox["mailbox_id"] == "mbx_one"
+
+
 def ok_transport() -> httpx.MockTransport:
     def handler(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(200, json={"ok": True, "data": {}, "meta": {"request_id": "req_test"}})
 
     return httpx.MockTransport(handler)
+
+
+def hosted_route(
+    operation_id: str,
+    tool_name: str,
+    surface: Surface,
+    path_template: str,
+    *,
+    method: str = "GET",
+) -> HostedOperationRoute:
+    return HostedOperationRoute(
+        operation_id=operation_id,
+        tool_name=tool_name,
+        surface=surface,
+        method=method,
+        path_template=path_template,
+        permissions=(),
+        path_pattern=path_template_pattern(path_template),
+    )
+
+
+def proxy_envelope(
+    transport: HostedProxyTransport,
+    request: httpx.Request,
+    route: HostedOperationRoute,
+) -> dict[str, Any]:
+    proxy_request = transport._proxy_request(
+        request,
+        route,
+        "mcp_grant_public",
+        request.url.path.removeprefix("/api/v1"),
+        b"",
+    )
+    return json.loads(proxy_request.content)


### PR DESCRIPTION
## Summary
- Add hosted MCP proxy regression coverage that verifies only mailbox-surface requests include `mailbox_id` in the proxy envelope.
- Cover management, sending, and mailbox routes at the SDK MCP proxy seam.

## Root cause
The live failure was server-side, but the SDK MCP client did not have a guard proving hosted proxy envelopes stay surface-specific.

## Verification
- `pnpm build:mcp`
- `.tmp/python-venv/bin/python -m mypy packages/python/mcp`
- `.tmp/python-venv/bin/python -m pytest packages/python/tests/test_mcp.py`
- `pnpm check:cli`
- `pnpm check:surface-coverage`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds hosted MCP proxy regression coverage for mailbox targeting by surface. The main changes are:

- Adds a test that builds management, sending, and mailbox proxy envelopes.
- Checks that only mailbox-surface envelopes receive a top-level `mailbox_id`.
- Adds small test helpers for hosted operation routes and proxy envelope decoding.

<h3>Confidence Score: 4/5</h3>

This appears mostly safe, but the new regression coverage misses the query path.

- The changed code is test-only.
- The intended guard can still pass while non-mailbox envelopes carry `mailbox_id` inside `query`.
- Production behavior was not changed by this PR.

- `packages/python/tests/test_mcp.py` should assert that non-mailbox envelope queries do not carry mailbox targeting.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/python/tests/test_mcp.py | Adds hosted proxy envelope coverage, but the non-mailbox assertions miss `mailbox_id` in the serialized query. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fpython%2Ftests%2Ftest_mcp.py%3A277-282%0A**Query%20still%20targets%20mailbox**%20The%20new%20check%20only%20verifies%20that%20non-mailbox%20envelopes%20omit%20the%20top-level%20%60mailbox_id%60%20key.%20These%20same%20management%20and%20sending%20envelopes%20still%20include%20%60mailbox_id%3Dmbx_one%60%20in%20their%20%60query%60%20field%20because%20%60_proxy_request%60%20serializes%20the%20full%20request%20query%20unchanged.%20If%20the%20hosted%20proxy%20uses%20any%20mailbox%20targeting%20data%20from%20the%20envelope%2C%20this%20regression%20test%20passes%20while%20non-mailbox%20requests%20can%20still%20arrive%20with%20mailbox%20targeting%20attached.%0A%0A%60%60%60suggestion%0A%20%20%20%20assert%20management%5B%22surface%22%5D%20%3D%3D%20%22management%22%0A%20%20%20%20assert%20%22mailbox_id%22%20not%20in%20management%0A%20%20%20%20assert%20%22mailbox_id%22%20not%20in%20management%5B%22query%22%5D%0A%20%20%20%20assert%20sending%5B%22surface%22%5D%20%3D%3D%20%22sending%22%0A%20%20%20%20assert%20%22mailbox_id%22%20not%20in%20sending%0A%20%20%20%20assert%20%22mailbox_id%22%20not%20in%20sending%5B%22query%22%5D%0A%20%20%20%20assert%20mailbox%5B%22surface%22%5D%20%3D%3D%20%22mailbox%22%0A%20%20%20%20assert%20mailbox%5B%22mailbox_id%22%5D%20%3D%3D%20%22mbx_one%22%0A%60%60%60%0A%0A&repo=sendmux%2Fsendmux-sdk&pr=21&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Guard hosted MCP mailbox targeting by su..."](https://github.com/sendmux/sendmux-sdk/commit/b02e0b4fc100cf0263504158e5ac548383947674) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36964986)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->