### PR TITLE
Guard mailbox targeting across MCP SDK and CLI

### DIFF
--- a/packages/python/mcp/tests/test_hosted_server.py
+++ b/packages/python/mcp/tests/test_hosted_server.py
@@ -5,6 +5,7 @@ import asyncio
 import httpx
 import pytest
 
+from sendmux_mcp.curation import MAILBOX_TOOLS
 from sendmux_mcp.hosted import (
     HOSTED_SURFACES,
     HostedServerRuntimeConfig,
@@ -142,6 +143,51 @@ def test_hosted_surface_children_keep_curated_tool_sets_without_process_api_key(
         assert "mailbox_get_me" in tool_names
         assert "management_list_domains" in tool_names
         assert "sending_send_email" in tool_names
+
+    asyncio.run(run())
+
+
+def test_hosted_mailbox_action_tools_expose_mailbox_target(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def run() -> None:
+        monkeypatch.delenv("SENDMUX_API_KEY", raising=False)
+
+        runtime = runtime_config()
+        auth_provider = create_remote_auth_provider(
+            HostedAuthConfig(
+                issuer=runtime.issuer,
+                authorization_servers=runtime.authorization_servers,
+                jwks_uri=runtime.jwks_uri,
+                resource_base_url=runtime.resource_base_url,
+                mcp_path=runtime.mcp_path,
+            )
+        )
+        surface_config = hosted_surface_config("mailbox", runtime)
+        child = create_server(
+            surface_config,
+            auth_provider=auth_provider,
+            hosted_proxy_config=HostedProxyConfig(
+                proxy_url=runtime.proxy_url,
+                upstream_base_url=surface_config.api_base_url,
+                internal_bearer_token=runtime.internal_bearer_token,
+            ),
+        )
+
+        tools = await child.list_tools(run_middleware=False)
+        tool_names = {tool.name for tool in tools}
+        expected_tool_names = {tool.name for tool in MAILBOX_TOOLS}
+        missing_target: list[str] = []
+
+        assert tool_names == expected_tool_names
+
+        for tool in tools:
+            properties = (tool.parameters or {}).get("properties", {})
+            if tool.name == "mailbox_list_granted_mailboxes":
+                assert "mailbox_id" not in properties
+                continue
+            if tool.name.startswith("mailbox_") and "mailbox_id" not in properties:
+                missing_target.append(tool.name)
+
+        assert missing_target == []
 
     asyncio.run(run())
 

--- a/scripts/check-cli.mjs
+++ b/scripts/check-cli.mjs
@@ -74,6 +74,24 @@ try {
   const parsed = JSON.parse(jsonResult.stdout);
   assertDeepEqual(parsed, envelope, "--json must emit the raw SDK response envelope");
 
+  const identityResult = await runCli([
+    "mailbox:get-identity",
+    "--api-key",
+    mailboxKey,
+    "--base-url",
+    baseUrl,
+    "--query",
+    "mailbox_id=mbx_cli_target",
+    "--json",
+  ]);
+
+  assertCliSuccess(identityResult, "mailbox:get-identity with mailbox_id query");
+  const identityRequest = latestRequest();
+  if (!identityRequest.url.startsWith("/mailbox/identity")) {
+    throw new Error(`mailbox:get-identity used the wrong path: ${identityRequest.url}`);
+  }
+  assertSearchParam(identityRequest.url, "mailbox_id", "mbx_cli_target");
+
   const countResult = await runCli([
     "mailbox:count-messages",
     "--api-key",

--- a/scripts/check-mcp.mjs
+++ b/scripts/check-mcp.mjs
@@ -25,7 +25,7 @@ run(python, [
 ]);
 run(python, ["-m", "compileall", "-q", "packages/python/mcp"]);
 run(python, ["-m", "mypy", "packages/python/mcp"]);
-run(python, ["-m", "pytest", "packages/python/tests/test_mcp.py"]);
+run(python, ["-m", "pytest", "packages/python/tests/test_mcp.py", "packages/python/mcp/tests"]);
 rmSync(distDir, { force: true, recursive: true });
 mkdirSync(distDir, { recursive: true });
 run(python, ["-m", "build", "--outdir", distDir, "packages/python/mcp"]);

--- a/scripts/check-python.mjs
+++ b/scripts/check-python.mjs
@@ -7,6 +7,7 @@ const venv = join(root, ".tmp", "python-venv");
 const python = join(venv, "bin", "python");
 
 checkGeneratedMailboxBodyParamOrder();
+checkGeneratedMailboxTargeting();
 
 if (!existsSync(python)) {
   mkdirSync(join(root, ".tmp"), { recursive: true });
@@ -84,6 +85,24 @@ function checkGeneratedMailboxBodyParamOrder() {
   }
 }
 
+function checkGeneratedMailboxTargeting() {
+  const filePath = join(root, "packages", "python", "mailbox", "sendmux_mailbox", "api", "mailbox_api_api.py");
+  const source = readFileSync(filePath, "utf8");
+
+  assertMethodContains({
+    source,
+    filePath,
+    anchor: "def mailbox_get_identity(",
+    expected: ["mailbox_id:", "mailbox_id=mailbox_id,"],
+  });
+  assertMethodContains({
+    source,
+    filePath,
+    anchor: "def _mailbox_get_identity_serialize(",
+    expected: ["mailbox_id,", "_query_params.append(('mailbox_id', mailbox_id))"],
+  });
+}
+
 function assertOrder({ source, filePath, anchor, first, second }) {
   const anchorIndex = source.indexOf(anchor);
   if (anchorIndex === -1) {
@@ -97,5 +116,20 @@ function assertOrder({ source, filePath, anchor, first, second }) {
   }
   if (secondIndex < firstIndex) {
     throw new Error(`Generated Python method ${anchor} places ${second} before ${first} in ${filePath}`);
+  }
+}
+
+function assertMethodContains({ source, filePath, anchor, expected }) {
+  const anchorIndex = source.indexOf(anchor);
+  if (anchorIndex === -1) {
+    throw new Error(`Missing generated Python method ${anchor} in ${filePath}`);
+  }
+
+  const methodEnd = source.indexOf("    def ", anchorIndex + anchor.length);
+  const methodSource = source.slice(anchorIndex, methodEnd === -1 ? undefined : methodEnd);
+  for (const value of expected) {
+    if (!methodSource.includes(value)) {
+      throw new Error(`Generated Python method ${anchor} is missing ${value} in ${filePath}`);
+    }
   }
 }

--- a/scripts/test-ts-helpers.mjs
+++ b/scripts/test-ts-helpers.mjs
@@ -13,6 +13,7 @@ const {
   paginate,
   responseEtag,
 } = await import("../packages/ts/core/dist/index.js");
+const { createMailboxClient, mailboxGetIdentity } = await import("../packages/ts/mailbox/dist/index.js");
 const { createSendingClient } = await import("../packages/ts/sending/dist/index.js");
 
 assert.equal(assertApiKeyKind("smx_root_test", "root"), "root");
@@ -243,6 +244,32 @@ await sendingB.get({
 assert.deepEqual(seenConfiguredRequests, [
   { authorization: "Bearer smx_mbx_test_a", url: "https://sdk-a.test/auth-check" },
   { authorization: "Bearer smx_mbx_test_b", url: "https://sdk-b.test/auth-check" },
+]);
+
+const seenMailboxRequests = [];
+const mailboxClient = createMailboxClient({
+  apiKey: "smx_mbx_test_mailbox",
+  baseUrl: "https://mailbox-sdk.test",
+  fetch: async (request) => {
+    seenMailboxRequests.push({
+      authorization: request.headers.get("Authorization"),
+      url: request.url,
+    });
+    return new Response(JSON.stringify({ ok: true, data: {}, meta: { request_id: "req_mailbox_identity" } }), {
+      headers: { "Content-Type": "application/json" },
+      status: 200,
+    });
+  },
+});
+await mailboxGetIdentity({
+  client: mailboxClient,
+  query: { mailbox_id: "mbx_ts_target" },
+});
+assert.deepEqual(seenMailboxRequests, [
+  {
+    authorization: "Bearer smx_mbx_test_mailbox",
+    url: "https://mailbox-sdk.test/mailbox/identity?mailbox_id=mbx_ts_target",
+  },
 ]);
 
 console.log("TypeScript core helper tests passed.");


### PR DESCRIPTION
## Summary
- add hosted MCP regression coverage that requires mailbox action tools to expose mailbox_id
- expand MCP build checks to run the hosted MCP test suite
- add CLI, Python SDK, and TypeScript SDK guards proving mailbox_get_identity can target a mailbox

## Verification
- pnpm build
- pnpm build:mcp
- pnpm check:cli
- node scripts/check-python.mjs
- pnpm test:ts-helpers

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds mailbox targeting checks across the MCP server, CLI, and generated SDK surfaces. The main changes are:

- Hosted MCP tests now require curated mailbox action tools to expose `mailbox_id`.
- MCP build checks now run the hosted MCP test suite.
- CLI checks now verify `mailbox:get-identity` forwards `mailbox_id` as a query parameter.
- Python and TypeScript SDK helper checks now guard `mailbox_get_identity` targeting.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (3): Last reviewed commit: ["Guard mailbox targeting across MCP SDK a..."](https://github.com/sendmux/sendmux-sdk/commit/abb55388ba1e0cf64b540a2f9977a445491f429c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37115084)</sub>

<!-- /greptile_comment -->