### PR TITLE
agent/hosted mcp hardening

### DIFF
--- a/packages/python/mcp/pyproject.toml
+++ b/packages/python/mcp/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
   "fastmcp==3.3.1",
   "httpx>=0.28.1,<1",
+  "sentry-sdk>=2.62.0,<3",
   "sendmux-core>=1.0.0,<2.0.0",
 ]
 

--- a/packages/python/mcp/sendmux_mcp/hosted.py
+++ b/packages/python/mcp/sendmux_mcp/hosted.py
@@ -177,8 +177,7 @@ def hosted_surface_config(surface: Surface, runtime: HostedServerRuntimeConfig) 
 
 
 def default_hosted_allowed_origins(app_origin: str) -> tuple[str, ...]:
-    origins = (app_origin,)
-    return tuple(dict.fromkeys(origin for origin in origins if origin))
+    return (app_origin,)
 
 
 def normalise_hosted_allowed_origins(origins: Sequence[str]) -> tuple[str, ...]:

--- a/packages/python/mcp/sendmux_mcp/hosted.py
+++ b/packages/python/mcp/sendmux_mcp/hosted.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Sequence
 from dataclasses import dataclass
 from urllib.parse import urlparse
 
@@ -14,13 +15,16 @@ from starlette.responses import JSONResponse
 from sendmux_mcp.config import DEFAULT_APP_BASE_URL, ServerConfig, Surface, config_from_env, parse_csv
 from sendmux_mcp.hosted_auth import HostedAuthConfig, create_remote_auth_provider
 from sendmux_mcp.hosted_proxy import HostedProxyConfig
+from sendmux_mcp.observability import init_sentry_from_env
 from sendmux_mcp.permissions import tool_permission_auth_check
+from sendmux_mcp.security import OriginGuardMiddleware
 from sendmux_mcp.server import create_server
 
 HOSTED_SURFACES: tuple[Surface, ...] = ("mailbox", "management", "sending")
 DEFAULT_MCP_RESOURCE_BASE_URL = "https://mcp.sendmux.ai"
 DEFAULT_MCP_APP_ORIGIN = "https://app.sendmux.ai"
 DEFAULT_MCP_PATH = "/mcp"
+HOSTED_LOCAL_CLIENT_ORIGINS = ("http://localhost:6274", "http://127.0.0.1:6274")
 HOSTED_CORS_ALLOWED_HEADERS = (
     "Accept",
     "Authorization",
@@ -46,6 +50,7 @@ class HostedServerRuntimeConfig:
     port: int
     stateless_http: bool
     scopes_supported: tuple[str, ...]
+    allowed_origins: tuple[str, ...]
 
 
 def hosted_runtime_config_from_env() -> HostedServerRuntimeConfig:
@@ -58,6 +63,9 @@ def hosted_runtime_config_from_env() -> HostedServerRuntimeConfig:
     authorization_servers = parse_csv(os.environ.get("SENDMUX_MCP_AUTHORIZATION_SERVERS")) or (issuer,)
     jwks_uri = os.environ.get("SENDMUX_MCP_JWKS_URI", f"{app_origin}/.well-known/jwks.json")
     proxy_url = os.environ.get("SENDMUX_MCP_PROXY_URL", f"{app_origin}/api/internal/mcp/proxy")
+    allowed_origins = normalise_hosted_allowed_origins(
+        parse_csv(os.environ.get("SENDMUX_MCP_ALLOWED_ORIGINS")) or default_hosted_allowed_origins(app_origin)
+    )
 
     return HostedServerRuntimeConfig(
         issuer=issuer,
@@ -71,6 +79,7 @@ def hosted_runtime_config_from_env() -> HostedServerRuntimeConfig:
         port=int(os.environ.get("SENDMUX_MCP_PORT", "8765")),
         stateless_http=True,
         scopes_supported=parse_csv(os.environ.get("SENDMUX_MCP_SCOPES_SUPPORTED")),
+        allowed_origins=allowed_origins,
     )
 
 
@@ -113,6 +122,7 @@ def create_hosted_server(runtime: HostedServerRuntimeConfig | None = None) -> Fa
 
 
 def run_hosted() -> None:
+    init_sentry_from_env()
     runtime = hosted_runtime_config_from_env()
     server = create_hosted_server(runtime)
     server.run(
@@ -120,17 +130,21 @@ def run_hosted() -> None:
         host=runtime.host,
         port=runtime.port,
         path=runtime.mcp_path,
-        middleware=hosted_http_middleware(),
+        middleware=hosted_http_middleware(runtime.allowed_origins),
         stateless_http=runtime.stateless_http,
         show_banner=False,
     )
 
 
-def hosted_http_middleware() -> list[Middleware]:
+def hosted_http_middleware(allowed_origins: Sequence[str] | None = None) -> list[Middleware]:
+    origins = normalise_hosted_allowed_origins(
+        allowed_origins or default_hosted_allowed_origins(DEFAULT_MCP_APP_ORIGIN)
+    )
     return [
+        Middleware(OriginGuardMiddleware, allowed_origins=origins),
         Middleware(
             CORSMiddleware,
-            allow_origins=["*"],
+            allow_origins=list(origins),
             allow_methods=HOSTED_CORS_ALLOWED_METHODS,
             allow_headers=HOSTED_CORS_ALLOWED_HEADERS,
             expose_headers=HOSTED_CORS_EXPOSE_HEADERS,
@@ -161,6 +175,18 @@ def hosted_surface_config(surface: Surface, runtime: HostedServerRuntimeConfig) 
         stateless_http=runtime.stateless_http,
         retry=base.retry,
     )
+
+
+def default_hosted_allowed_origins(app_origin: str) -> tuple[str, ...]:
+    origins = (app_origin, *HOSTED_LOCAL_CLIENT_ORIGINS)
+    return tuple(dict.fromkeys(origin for origin in origins if origin))
+
+
+def normalise_hosted_allowed_origins(origins: Sequence[str]) -> tuple[str, ...]:
+    normalised = tuple(dict.fromkeys(origin for origin in origins if origin))
+    if "*" in normalised:
+        raise ValueError("Hosted MCP requires explicit allowed origins; wildcard '*' is not allowed.")
+    return normalised
 
 
 def origin_from_url(value: str) -> str:

--- a/packages/python/mcp/sendmux_mcp/hosted.py
+++ b/packages/python/mcp/sendmux_mcp/hosted.py
@@ -24,7 +24,6 @@ HOSTED_SURFACES: tuple[Surface, ...] = ("mailbox", "management", "sending")
 DEFAULT_MCP_RESOURCE_BASE_URL = "https://mcp.sendmux.ai"
 DEFAULT_MCP_APP_ORIGIN = "https://app.sendmux.ai"
 DEFAULT_MCP_PATH = "/mcp"
-HOSTED_LOCAL_CLIENT_ORIGINS = ("http://localhost:6274", "http://127.0.0.1:6274")
 HOSTED_CORS_ALLOWED_HEADERS = (
     "Accept",
     "Authorization",
@@ -178,7 +177,7 @@ def hosted_surface_config(surface: Surface, runtime: HostedServerRuntimeConfig) 
 
 
 def default_hosted_allowed_origins(app_origin: str) -> tuple[str, ...]:
-    origins = (app_origin, *HOSTED_LOCAL_CLIENT_ORIGINS)
+    origins = (app_origin,)
     return tuple(dict.fromkeys(origin for origin in origins if origin))
 
 

--- a/packages/python/mcp/sendmux_mcp/observability.py
+++ b/packages/python/mcp/sendmux_mcp/observability.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping, MutableMapping
+from dataclasses import dataclass
+from typing import Any, cast
+
+from sentry_sdk.types import Event, Hint
+
+
+SENSITIVE_KEYS = {
+    "access_token",
+    "api_key",
+    "authorization",
+    "claims",
+    "cookie",
+    "cookies",
+    "grant_id",
+    "id_token",
+    "jwt",
+    "mailbox_ids",
+    "mcp_session_id",
+    "password",
+    "permissions",
+    "proxy_authorization",
+    "refresh_token",
+    "scope",
+    "secret",
+    "set_cookie",
+    "sub",
+    "team_public_id",
+    "token",
+}
+
+
+@dataclass(frozen=True)
+class SentryConfig:
+    dsn: str
+    environment: str
+    release: str | None
+    traces_sample_rate: float
+
+
+def sentry_config_from_env(env: Mapping[str, str] = os.environ) -> SentryConfig | None:
+    dsn = clean(env.get("SENTRY_DSN")) or clean(env.get("NEXT_PUBLIC_SENTRY_DSN"))
+    if not dsn:
+        return None
+
+    return SentryConfig(
+        dsn=dsn,
+        environment=clean(env.get("SENTRY_ENVIRONMENT"))
+        or clean(env.get("ENVIRONMENT"))
+        or clean(env.get("NODE_ENV"))
+        or "unknown",
+        release=clean(env.get("SENDMUX_MCP_RELEASE")) or clean(env.get("SENTRY_RELEASE")),
+        traces_sample_rate=parse_sample_rate(env.get("SENTRY_TRACES_SAMPLE_RATE")),
+    )
+
+
+def init_sentry_from_env(env: Mapping[str, str] = os.environ) -> bool:
+    config = sentry_config_from_env(env)
+    if config is None:
+        return False
+
+    import sentry_sdk
+    from sentry_sdk.integrations.starlette import StarletteIntegration
+
+    sentry_sdk.init(
+        dsn=config.dsn,
+        environment=config.environment,
+        release=config.release,
+        traces_sample_rate=config.traces_sample_rate,
+        send_default_pii=False,
+        max_request_body_size="never",
+        include_local_variables=False,
+        integrations=[StarletteIntegration()],
+        before_send=scrub_sentry_event,
+    )
+    sentry_sdk.set_tag("service", "sendmux-mcp")
+    return True
+
+
+def scrub_sentry_event(event: Event, _hint: Hint) -> Event | None:
+    request = event.get("request")
+    if isinstance(request, MutableMapping):
+        request.pop("data", None)
+        request.pop("cookies", None)
+        request.pop("env", None)
+
+    scrub_sensitive_values(cast(MutableMapping[str, Any], event))
+    return event
+
+
+def scrub_sensitive_values(value: Any) -> None:
+    if isinstance(value, MutableMapping):
+        for key in list(value.keys()):
+            if is_sensitive_key(str(key)):
+                value[key] = "[Filtered]"
+                continue
+            scrub_sensitive_values(value[key])
+    elif isinstance(value, list):
+        for item in value:
+            scrub_sensitive_values(item)
+
+
+def is_sensitive_key(key: str) -> bool:
+    normalised = key.lower().replace("-", "_")
+    return (
+        normalised in SENSITIVE_KEYS
+        or normalised.endswith("_token")
+        or normalised.endswith("_secret")
+        or "authorization" in normalised
+    )
+
+
+def parse_sample_rate(value: str | None) -> float:
+    if value is None or not value.strip():
+        return 0.0
+    try:
+        parsed = float(value)
+    except ValueError:
+        return 0.0
+    return min(1.0, max(0.0, parsed))
+
+
+def clean(value: str | None) -> str | None:
+    trimmed = value.strip() if value else ""
+    return trimmed or None

--- a/packages/python/mcp/sendmux_mcp/observability.py
+++ b/packages/python/mcp/sendmux_mcp/observability.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Mapping, MutableMapping
+from collections.abc import MutableMapping
 from dataclasses import dataclass
 from typing import Any, cast
 
+import sentry_sdk
+from sentry_sdk.integrations.starlette import StarletteIntegration
 from sentry_sdk.types import Event, Hint
 
 
@@ -41,29 +43,29 @@ class SentryConfig:
     traces_sample_rate: float
 
 
-def sentry_config_from_env(env: Mapping[str, str] = os.environ) -> SentryConfig | None:
-    dsn = clean(env.get("SENTRY_DSN")) or clean(env.get("NEXT_PUBLIC_SENTRY_DSN"))
+def sentry_config_from_env() -> SentryConfig | None:
+    dsn = clean_env_value(os.environ.get("SENTRY_DSN")) or clean_env_value(
+        os.environ.get("NEXT_PUBLIC_SENTRY_DSN")
+    )
     if not dsn:
         return None
 
     return SentryConfig(
         dsn=dsn,
-        environment=clean(env.get("SENTRY_ENVIRONMENT"))
-        or clean(env.get("ENVIRONMENT"))
-        or clean(env.get("NODE_ENV"))
+        environment=clean_env_value(os.environ.get("SENTRY_ENVIRONMENT"))
+        or clean_env_value(os.environ.get("ENVIRONMENT"))
+        or clean_env_value(os.environ.get("NODE_ENV"))
         or "unknown",
-        release=clean(env.get("SENDMUX_MCP_RELEASE")) or clean(env.get("SENTRY_RELEASE")),
-        traces_sample_rate=parse_sample_rate(env.get("SENTRY_TRACES_SAMPLE_RATE")),
+        release=clean_env_value(os.environ.get("SENDMUX_MCP_RELEASE"))
+        or clean_env_value(os.environ.get("SENTRY_RELEASE")),
+        traces_sample_rate=parse_sample_rate(os.environ.get("SENTRY_TRACES_SAMPLE_RATE")),
     )
 
 
-def init_sentry_from_env(env: Mapping[str, str] = os.environ) -> bool:
-    config = sentry_config_from_env(env)
+def init_sentry_from_env() -> bool:
+    config = sentry_config_from_env()
     if config is None:
         return False
-
-    import sentry_sdk
-    from sentry_sdk.integrations.starlette import StarletteIntegration
 
     sentry_sdk.init(
         dsn=config.dsn,
@@ -123,6 +125,6 @@ def parse_sample_rate(value: str | None) -> float:
     return min(1.0, max(0.0, parsed))
 
 
-def clean(value: str | None) -> str | None:
+def clean_env_value(value: str | None) -> str | None:
     trimmed = value.strip() if value else ""
     return trimmed or None

--- a/packages/python/mcp/sendmux_mcp/observability.py
+++ b/packages/python/mcp/sendmux_mcp/observability.py
@@ -111,6 +111,7 @@ def is_sensitive_key(key: str) -> bool:
         normalised in SENSITIVE_KEYS
         or normalised.endswith("_token")
         or normalised.endswith("_secret")
+        or normalised.endswith("_api_key")
         or "authorization" in normalised
     )
 

--- a/packages/python/mcp/tests/test_hosted_server.py
+++ b/packages/python/mcp/tests/test_hosted_server.py
@@ -33,6 +33,7 @@ def runtime_config() -> HostedServerRuntimeConfig:
         port=8765,
         stateless_http=True,
         scopes_supported=("mailbox.read", "email.send"),
+        allowed_origins=("https://app.sendmux.ai", "http://localhost:6274", "http://127.0.0.1:6274"),
     )
 
 
@@ -66,11 +67,57 @@ def test_hosted_server_allows_browser_preflight_to_mcp_endpoint() -> None:
             )
 
         assert response.status_code == 200
-        assert response.headers["access-control-allow-origin"] == "*"
+        assert response.headers["access-control-allow-origin"] == "http://localhost:6274"
         assert "authorization" in response.headers["access-control-allow-headers"].lower()
         assert "mcp-protocol-version" in response.headers["access-control-allow-headers"].lower()
         assert "post" in response.headers["access-control-allow-methods"].lower()
         assert "access-control-allow-credentials" not in response.headers
+
+    asyncio.run(run())
+
+
+def test_hosted_server_rejects_unknown_browser_origin_before_auth() -> None:
+    async def run() -> None:
+        server = create_hosted_server(runtime_config())
+        app = server.http_app(path="/mcp", middleware=hosted_http_middleware(), stateless_http=True)
+        transport = httpx.ASGITransport(app=app)
+
+        async with httpx.AsyncClient(transport=transport, base_url="https://mcp.sendmux.ai") as client:
+            response = await client.post(
+                "/mcp",
+                headers={
+                    "Origin": "https://evil.example",
+                    "Content-Type": "application/json",
+                    "MCP-Protocol-Version": "2025-11-25",
+                },
+                json={"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+            )
+
+        assert response.status_code == 403
+        assert response.json()["error"]["code"] == "origin_forbidden"
+        assert "www-authenticate" not in response.headers
+
+    asyncio.run(run())
+
+
+def test_hosted_server_rejects_unknown_browser_preflight() -> None:
+    async def run() -> None:
+        server = create_hosted_server(runtime_config())
+        app = server.http_app(path="/mcp", middleware=hosted_http_middleware(), stateless_http=True)
+        transport = httpx.ASGITransport(app=app)
+
+        async with httpx.AsyncClient(transport=transport, base_url="https://mcp.sendmux.ai") as client:
+            response = await client.options(
+                "/mcp",
+                headers={
+                    "Origin": "https://evil.example",
+                    "Access-Control-Request-Method": "POST",
+                    "Access-Control-Request-Headers": "authorization,content-type,mcp-protocol-version",
+                },
+            )
+
+        assert response.status_code == 403
+        assert response.json()["error"]["code"] == "origin_forbidden"
 
     asyncio.run(run())
 
@@ -92,7 +139,7 @@ def test_hosted_server_exposes_mcp_headers_to_browser_requests() -> None:
                 json={"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
             )
 
-        assert response.headers["access-control-allow-origin"] == "*"
+        assert response.headers["access-control-allow-origin"] == "http://localhost:6274"
         assert "mcp-protocol-version" in response.headers["access-control-expose-headers"].lower()
         assert "mcp-session-id" in response.headers["access-control-expose-headers"].lower()
         assert "access-control-allow-credentials" not in response.headers
@@ -200,6 +247,7 @@ def test_hosted_runtime_config_uses_public_resource_and_internal_proxy_env(
     monkeypatch.setenv("SENDMUX_MCP_PROXY_URL", "http://sendmux-app.sendmux.svc.cluster.local/api/internal/mcp/proxy")
     monkeypatch.setenv("INTERNAL_API_SECRET", "internal-service-token")
     monkeypatch.setenv("SENDMUX_MCP_SCOPES_SUPPORTED", "mailbox.read,email.send")
+    monkeypatch.setenv("SENDMUX_MCP_ALLOWED_ORIGINS", "https://app.sendmux.ai,http://localhost:6274")
 
     config = hosted_runtime_config_from_env()
 
@@ -209,6 +257,14 @@ def test_hosted_runtime_config_uses_public_resource_and_internal_proxy_env(
     assert config.proxy_url == "http://sendmux-app.sendmux.svc.cluster.local/api/internal/mcp/proxy"
     assert config.internal_bearer_token == "internal-service-token"
     assert config.scopes_supported == ("mailbox.read", "email.send")
+    assert config.allowed_origins == ("https://app.sendmux.ai", "http://localhost:6274")
+
+
+def test_hosted_runtime_config_rejects_wildcard_origin(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SENDMUX_MCP_ALLOWED_ORIGINS", "*")
+
+    with pytest.raises(ValueError, match="wildcard"):
+        hosted_runtime_config_from_env()
 
 
 def test_origin_from_url_strips_api_path() -> None:

--- a/packages/python/mcp/tests/test_hosted_server.py
+++ b/packages/python/mcp/tests/test_hosted_server.py
@@ -33,7 +33,7 @@ def runtime_config() -> HostedServerRuntimeConfig:
         port=8765,
         stateless_http=True,
         scopes_supported=("mailbox.read", "email.send"),
-        allowed_origins=("https://app.sendmux.ai", "http://localhost:6274", "http://127.0.0.1:6274"),
+        allowed_origins=("https://app.sendmux.ai",),
     )
 
 
@@ -50,7 +50,7 @@ def test_hosted_server_mounts_all_surfaces_without_process_api_key(monkeypatch: 
     asyncio.run(run())
 
 
-def test_hosted_server_allows_browser_preflight_to_mcp_endpoint() -> None:
+def test_hosted_server_rejects_localhost_browser_preflight_by_default() -> None:
     async def run() -> None:
         server = create_hosted_server(runtime_config())
         app = server.http_app(path="/mcp", middleware=hosted_http_middleware(), stateless_http=True)
@@ -66,8 +66,30 @@ def test_hosted_server_allows_browser_preflight_to_mcp_endpoint() -> None:
                 },
             )
 
+        assert response.status_code == 403
+        assert response.json()["error"]["code"] == "origin_forbidden"
+
+    asyncio.run(run())
+
+
+def test_hosted_server_allows_browser_preflight_from_app_origin() -> None:
+    async def run() -> None:
+        server = create_hosted_server(runtime_config())
+        app = server.http_app(path="/mcp", middleware=hosted_http_middleware(), stateless_http=True)
+        transport = httpx.ASGITransport(app=app)
+
+        async with httpx.AsyncClient(transport=transport, base_url="https://mcp.sendmux.ai") as client:
+            response = await client.options(
+                "/mcp",
+                headers={
+                    "Origin": "https://app.sendmux.ai",
+                    "Access-Control-Request-Method": "POST",
+                    "Access-Control-Request-Headers": "authorization,content-type,mcp-protocol-version",
+                },
+            )
+
         assert response.status_code == 200
-        assert response.headers["access-control-allow-origin"] == "http://localhost:6274"
+        assert response.headers["access-control-allow-origin"] == "https://app.sendmux.ai"
         assert "authorization" in response.headers["access-control-allow-headers"].lower()
         assert "mcp-protocol-version" in response.headers["access-control-allow-headers"].lower()
         assert "post" in response.headers["access-control-allow-methods"].lower()
@@ -132,14 +154,14 @@ def test_hosted_server_exposes_mcp_headers_to_browser_requests() -> None:
             response = await client.post(
                 "/mcp",
                 headers={
-                    "Origin": "http://localhost:6274",
+                    "Origin": "https://app.sendmux.ai",
                     "Content-Type": "application/json",
                     "MCP-Protocol-Version": "2025-11-25",
                 },
                 json={"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
             )
 
-        assert response.headers["access-control-allow-origin"] == "http://localhost:6274"
+        assert response.headers["access-control-allow-origin"] == "https://app.sendmux.ai"
         assert "mcp-protocol-version" in response.headers["access-control-expose-headers"].lower()
         assert "mcp-session-id" in response.headers["access-control-expose-headers"].lower()
         assert "access-control-allow-credentials" not in response.headers
@@ -258,6 +280,15 @@ def test_hosted_runtime_config_uses_public_resource_and_internal_proxy_env(
     assert config.internal_bearer_token == "internal-service-token"
     assert config.scopes_supported == ("mailbox.read", "email.send")
     assert config.allowed_origins == ("https://app.sendmux.ai", "http://localhost:6274")
+
+
+def test_hosted_runtime_config_defaults_to_app_origin_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SENDMUX_MCP_APP_ORIGIN", "https://app.sendmux.ai")
+    monkeypatch.delenv("SENDMUX_MCP_ALLOWED_ORIGINS", raising=False)
+
+    config = hosted_runtime_config_from_env()
+
+    assert config.allowed_origins == ("https://app.sendmux.ai",)
 
 
 def test_hosted_runtime_config_rejects_wildcard_origin(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/python/mcp/tests/test_observability.py
+++ b/packages/python/mcp/tests/test_observability.py
@@ -52,6 +52,7 @@ def test_sentry_scrubber_removes_request_body_and_sensitive_headers() -> None:
                 "Cookie": "session=value",
                 "Mcp-Session-Id": "session-id",
                 "User-Agent": "test-client",
+                "X-Api-Key": "root-key",
             },
             "cookies": {"session": "value"},
             "data": {"jsonrpc": "2.0"},
@@ -78,6 +79,7 @@ def test_sentry_scrubber_removes_request_body_and_sensitive_headers() -> None:
     assert headers["Authorization"] == "[Filtered]"
     assert headers["Cookie"] == "[Filtered]"
     assert headers["Mcp-Session-Id"] == "[Filtered]"
+    assert headers["X-Api-Key"] == "[Filtered]"
     assert headers["User-Agent"] == "test-client"
     assert extra["grant_id"] == "[Filtered]"
     assert extra["access_token"] == "[Filtered]"

--- a/packages/python/mcp/tests/test_observability.py
+++ b/packages/python/mcp/tests/test_observability.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from collections.abc import MutableMapping
+from typing import Any, cast
+
+from sentry_sdk.types import Event
+
+from sendmux_mcp.observability import scrub_sentry_event, sentry_config_from_env
+
+
+def test_sentry_config_from_env_is_disabled_without_dsn() -> None:
+    assert sentry_config_from_env({}) is None
+
+
+def test_sentry_config_from_env_uses_privacy_minimized_defaults() -> None:
+    config = sentry_config_from_env(
+        {
+            "NEXT_PUBLIC_SENTRY_DSN": "https://public@example.invalid/1",
+            "SENTRY_ENVIRONMENT": "production",
+            "SENDMUX_MCP_RELEASE": "v1.0.4",
+        }
+    )
+
+    assert config is not None
+    assert config.dsn == "https://public@example.invalid/1"
+    assert config.environment == "production"
+    assert config.release == "v1.0.4"
+    assert config.traces_sample_rate == 0.0
+
+
+def test_sentry_scrubber_removes_request_body_and_sensitive_headers() -> None:
+    event = cast(Event, {
+        "request": {
+            "headers": {
+                "Authorization": "Bearer client-token",
+                "Cookie": "session=value",
+                "Mcp-Session-Id": "session-id",
+                "User-Agent": "test-client",
+            },
+            "cookies": {"session": "value"},
+            "data": {"jsonrpc": "2.0"},
+            "env": {"authorization": "Bearer client-token"},
+        },
+        "extra": {
+            "grant_id": "grant",
+            "access_token": "token",
+            "nested": {"team_public_id": "team", "safe": "kept"},
+        },
+    })
+
+    scrubbed = scrub_sentry_event(event, {})
+    assert scrubbed is not None
+
+    request = cast(MutableMapping[str, Any], scrubbed["request"])
+    headers = cast(MutableMapping[str, Any], request["headers"])
+    extra = cast(MutableMapping[str, Any], scrubbed["extra"])
+    nested = cast(MutableMapping[str, Any], extra["nested"])
+
+    assert "data" not in request
+    assert "cookies" not in request
+    assert "env" not in request
+    assert headers["Authorization"] == "[Filtered]"
+    assert headers["Cookie"] == "[Filtered]"
+    assert headers["Mcp-Session-Id"] == "[Filtered]"
+    assert headers["User-Agent"] == "test-client"
+    assert extra["grant_id"] == "[Filtered]"
+    assert extra["access_token"] == "[Filtered]"
+    assert nested["team_public_id"] == "[Filtered]"
+    assert nested["safe"] == "kept"

--- a/packages/python/mcp/tests/test_observability.py
+++ b/packages/python/mcp/tests/test_observability.py
@@ -3,23 +3,39 @@ from __future__ import annotations
 from collections.abc import MutableMapping
 from typing import Any, cast
 
+import pytest
 from sentry_sdk.types import Event
 
 from sendmux_mcp.observability import scrub_sentry_event, sentry_config_from_env
 
 
-def test_sentry_config_from_env_is_disabled_without_dsn() -> None:
-    assert sentry_config_from_env({}) is None
+def clear_sentry_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in (
+        "SENTRY_DSN",
+        "NEXT_PUBLIC_SENTRY_DSN",
+        "SENTRY_ENVIRONMENT",
+        "ENVIRONMENT",
+        "NODE_ENV",
+        "SENDMUX_MCP_RELEASE",
+        "SENTRY_RELEASE",
+        "SENTRY_TRACES_SAMPLE_RATE",
+    ):
+        monkeypatch.delenv(key, raising=False)
 
 
-def test_sentry_config_from_env_uses_privacy_minimized_defaults() -> None:
-    config = sentry_config_from_env(
-        {
-            "NEXT_PUBLIC_SENTRY_DSN": "https://public@example.invalid/1",
-            "SENTRY_ENVIRONMENT": "production",
-            "SENDMUX_MCP_RELEASE": "v1.0.4",
-        }
-    )
+def test_sentry_config_from_env_is_disabled_without_dsn(monkeypatch: pytest.MonkeyPatch) -> None:
+    clear_sentry_env(monkeypatch)
+
+    assert sentry_config_from_env() is None
+
+
+def test_sentry_config_from_env_uses_privacy_minimized_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    clear_sentry_env(monkeypatch)
+    monkeypatch.setenv("NEXT_PUBLIC_SENTRY_DSN", "https://public@example.invalid/1")
+    monkeypatch.setenv("SENTRY_ENVIRONMENT", "production")
+    monkeypatch.setenv("SENDMUX_MCP_RELEASE", "v1.0.4")
+
+    config = sentry_config_from_env()
 
     assert config is not None
     assert config.dsn == "https://public@example.invalid/1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ module = [
   "sendmux_mailbox.*",
   "sendmux_management.*",
   "fastmcp.*",
+  "sentry_sdk.*",
   "starlette.*",
 ]
 ignore_missing_imports = true


### PR DESCRIPTION
- **Harden hosted MCP HTTP surface**
- **Tighten hosted MCP production origins**
- **Align hosted MCP observability helpers**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the hosted MCP HTTP surface and adds hosted observability support. It changes:

- Adds explicit hosted MCP allowed-origin handling and CORS restrictions.
- Initializes Sentry for the hosted MCP server from environment configuration.
- Adds Sentry event scrubbing for request bodies, cookies, env data, and sensitive keys.
- Updates hosted server and observability tests for the new hardening behavior.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The reported `X-Api-Key` scrubber gap is covered by the latest matcher update and test.



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/python/mcp/sendmux_mcp/hosted.py`, line 56-67 ([link](https://github.com/sendmux/sendmux-sdk/blob/e98f36e8ae2d0e23f3b81848a80add231508191a/packages/python/mcp/sendmux_mcp/hosted.py#L56-L67)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Canonicalize app origin**

   When `SENDMUX_MCP_APP_ORIGIN` is set, this path uses the value verbatim as the default allowed browser origin. If it is configured as `https://app.sendmux.ai/` or `https://app.sendmux.ai/api/v1`, browsers still send `Origin: https://app.sendmux.ai`, so both `OriginGuardMiddleware` and CORS reject valid hosted MCP requests with 403. The fallback `SENDMUX_APP_BASE_URL` path already extracts the URL origin; the explicit hosted app origin should do the same before it feeds `allowed_origins`.

   

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fpython%2Fmcp%2Fsendmux_mcp%2Fhosted.py%0ALine%3A%2056-67%0A%0AComment%3A%0A**Canonicalize%20app%20origin**%0A%0AWhen%20%60SENDMUX_MCP_APP_ORIGIN%60%20is%20set%2C%20this%20path%20uses%20the%20value%20verbatim%20as%20the%20default%20allowed%20browser%20origin.%20If%20it%20is%20configured%20as%20%60https%3A%2F%2Fapp.sendmux.ai%2F%60%20or%20%60https%3A%2F%2Fapp.sendmux.ai%2Fapi%2Fv1%60%2C%20browsers%20still%20send%20%60Origin%3A%20https%3A%2F%2Fapp.sendmux.ai%60%2C%20so%20both%20%60OriginGuardMiddleware%60%20and%20CORS%20reject%20valid%20hosted%20MCP%20requests%20with%20403.%20The%20fallback%20%60SENDMUX_APP_BASE_URL%60%20path%20already%20extracts%20the%20URL%20origin%3B%20the%20explicit%20hosted%20app%20origin%20should%20do%20the%20same%20before%20it%20feeds%20%60allowed_origins%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20configured_app_origin%20%3D%20os.environ.get%28%22SENDMUX_MCP_APP_ORIGIN%22%29%0A%20%20%20%20app_origin%20%3D%20origin_from_url%28%0A%20%20%20%20%20%20%20%20configured_app_origin%20or%20os.environ.get%28%22SENDMUX_APP_BASE_URL%22%2C%20DEFAULT_APP_BASE_URL%29%0A%20%20%20%20%29%0A%20%20%20%20resource_base_url%20%3D%20os.environ.get%28%22SENDMUX_MCP_RESOURCE_BASE_URL%22%2C%20DEFAULT_MCP_RESOURCE_BASE_URL%29%0A%20%20%20%20mcp_path%20%3D%20os.environ.get%28%22SENDMUX_MCP_PATH%22%2C%20DEFAULT_MCP_PATH%29%0A%20%20%20%20issuer%20%3D%20os.environ.get%28%22SENDMUX_MCP_OAUTH_ISSUER%22%2C%20app_origin%29%0A%20%20%20%20authorization_servers%20%3D%20parse_csv%28os.environ.get%28%22SENDMUX_MCP_AUTHORIZATION_SERVERS%22%29%29%20or%20%28issuer%2C%29%0A%20%20%20%20jwks_uri%20%3D%20os.environ.get%28%22SENDMUX_MCP_JWKS_URI%22%2C%20f%22%7Bapp_origin%7D%2F.well-known%2Fjwks.json%22%29%0A%20%20%20%20proxy_url%20%3D%20os.environ.get%28%22SENDMUX_MCP_PROXY_URL%22%2C%20f%22%7Bapp_origin%7D%2Fapi%2Finternal%2Fmcp%2Fproxy%22%29%0A%20%20%20%20allowed_origins%20%3D%20normalise_hosted_allowed_origins%28%0A%20%20%20%20%20%20%20%20parse_csv%28os.environ.get%28%22SENDMUX_MCP_ALLOWED_ORIGINS%22%29%29%20or%20default_hosted_allowed_origins%28app_origin%29%0A%20%20%20%20%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=sendmux%2Fsendmux-sdk&pr=24&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Scrub API key headers from MCP Sentry ev..."](https://github.com/sendmux/sendmux-sdk/commit/01bdfb1fb53f8a1ad905549dc5cfd7f816a2dbb4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37826843)</sub>

<!-- /greptile_comment -->