### PR TITLE
fix: unpin python MCP release override

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -79,8 +79,7 @@
       "component": "python-mcp",
       "package-name": "sendmux-mcp",
       "release-type": "python",
-      "initial-version": "1.0.0",
-      "release-as": "1.0.0"
+      "initial-version": "1.0.0"
     },
     "go": {
       "component": "go",


### PR DESCRIPTION
## Summary
- remove the one-time python-mcp release-as override after the initial 1.0.0 release
- prevents release-please from keeping duplicate python-mcp 1.0.0 release PRs open

## Verification
- node JSON parse release-please-config.json
- pnpm canary:openapi -- --docs-dir ../sendmux-docs
- pnpm build:python:dists
- pnpm prepare:publish:pypi

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the stale python MCP release override from Release Please. The main changes are:

- Drops the forced `release-as` value for `packages/python/mcp`.
- Keeps the python MCP package on `initial-version` `1.0.0`.
- Lets Release Please compute future python MCP releases from the manifest and existing tag.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The manifest already records `packages/python/mcp` at `1.0.0`.
- The existing `python-mcp-v1.0.0` tag matches the package component naming.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| release-please-config.json | Removes the one-time forced python MCP release version while leaving the package path, component, package name, release type, and initial version unchanged. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: unpin python MCP release override"](https://github.com/sendmux/sendmux-sdk/commit/4d229317d1f75cb98860fc38f84dfc1d8c0424b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38034953)</sub>

<!-- /greptile_comment -->