### PR TITLE
fix: keep generated python package versions current

### DIFF
--- a/packages/python/mailbox/sendmux_mailbox/api_client.py
+++ b/packages/python/mailbox/sendmux_mailbox/api_client.py
@@ -91,7 +91,7 @@ class ApiClient:
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = 'OpenAPI-Generator/1.0.0/python'
+        self.user_agent = 'OpenAPI-Generator/1.0.1/python'
         self.client_side_validation = configuration.client_side_validation
 
     def __enter__(self):

--- a/packages/python/mailbox/sendmux_mailbox/configuration.py
+++ b/packages/python/mailbox/sendmux_mailbox/configuration.py
@@ -534,7 +534,7 @@ class Configuration:
                "OS: {env}\n"\
                "Python Version: {pyversion}\n"\
                "Version of the API: 1.0.0\n"\
-               "SDK Package Version: 1.0.0".\
+               "SDK Package Version: 1.0.1".\
                format(env=sys.platform, pyversion=sys.version)
 
     def get_host_settings(self) -> List[HostSetting]:

--- a/packages/python/management/sendmux_management/api_client.py
+++ b/packages/python/management/sendmux_management/api_client.py
@@ -91,7 +91,7 @@ class ApiClient:
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = 'OpenAPI-Generator/1.0.0/python'
+        self.user_agent = 'OpenAPI-Generator/1.0.1/python'
         self.client_side_validation = configuration.client_side_validation
 
     def __enter__(self):

--- a/packages/python/management/sendmux_management/configuration.py
+++ b/packages/python/management/sendmux_management/configuration.py
@@ -534,7 +534,7 @@ class Configuration:
                "OS: {env}\n"\
                "Python Version: {pyversion}\n"\
                "Version of the API: 1.0.0\n"\
-               "SDK Package Version: 1.0.0".\
+               "SDK Package Version: 1.0.1".\
                format(env=sys.platform, pyversion=sys.version)
 
     def get_host_settings(self) -> List[HostSetting]:

--- a/packages/python/sending/sendmux_sending/api_client.py
+++ b/packages/python/sending/sendmux_sending/api_client.py
@@ -91,7 +91,7 @@ class ApiClient:
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = 'OpenAPI-Generator/1.0.0/python'
+        self.user_agent = 'OpenAPI-Generator/1.0.1/python'
         self.client_side_validation = configuration.client_side_validation
 
     def __enter__(self):

--- a/packages/python/sending/sendmux_sending/configuration.py
+++ b/packages/python/sending/sendmux_sending/configuration.py
@@ -533,7 +533,7 @@ class Configuration:
                "OS: {env}\n"\
                "Python Version: {pyversion}\n"\
                "Version of the API: 1.0.0\n"\
-               "SDK Package Version: 1.0.0".\
+               "SDK Package Version: 1.0.1".\
                format(env=sys.platform, pyversion=sys.version)
 
     def get_host_settings(self) -> List[HostSetting]:

--- a/scripts/check-python.mjs
+++ b/scripts/check-python.mjs
@@ -8,6 +8,7 @@ const python = join(venv, "bin", "python");
 
 checkGeneratedMailboxBodyParamOrder();
 checkGeneratedMailboxTargeting();
+checkGeneratedPackageVersions();
 
 if (!existsSync(python)) {
   mkdirSync(join(root, ".tmp"), { recursive: true });
@@ -101,6 +102,63 @@ function checkGeneratedMailboxTargeting() {
     anchor: "def _mailbox_get_identity_serialize(",
     expected: ["mailbox_id,", "_query_params.append(('mailbox_id', mailbox_id))"],
   });
+}
+
+function checkGeneratedPackageVersions() {
+  const generatedPackages = [
+    {
+      packageDir: join(root, "packages", "python", "sending"),
+      moduleDir: join(root, "packages", "python", "sending", "sendmux_sending"),
+    },
+    {
+      packageDir: join(root, "packages", "python", "mailbox"),
+      moduleDir: join(root, "packages", "python", "mailbox", "sendmux_mailbox"),
+    },
+    {
+      packageDir: join(root, "packages", "python", "management"),
+      moduleDir: join(root, "packages", "python", "management", "sendmux_management"),
+    },
+  ];
+
+  for (const generatedPackage of generatedPackages) {
+    const pyprojectVersion = readPythonProjectVersion(generatedPackage.packageDir);
+    assertGeneratedVersion({
+      filePath: join(generatedPackage.moduleDir, "__init__.py"),
+      pattern: /^__version__ = "([^"]+)"$/m,
+      label: "__version__",
+      expected: pyprojectVersion,
+    });
+    assertGeneratedVersion({
+      filePath: join(generatedPackage.moduleDir, "api_client.py"),
+      pattern: /self\.user_agent = 'OpenAPI-Generator\/([^/']+)\/python'/,
+      label: "User-Agent package version",
+      expected: pyprojectVersion,
+    });
+    assertGeneratedVersion({
+      filePath: join(generatedPackage.moduleDir, "configuration.py"),
+      pattern: /"SDK Package Version: ([^"]+)"/,
+      label: "debug-report SDK package version",
+      expected: pyprojectVersion,
+    });
+  }
+}
+
+function assertGeneratedVersion({ filePath, pattern, label, expected }) {
+  const source = readFileSync(filePath, "utf8");
+  const actual = source.match(pattern)?.[1];
+  if (actual !== expected) {
+    throw new Error(`${filePath} has ${label} ${actual ?? "<missing>"} but pyproject.toml has ${expected}`);
+  }
+}
+
+function readPythonProjectVersion(packageDir) {
+  const pyprojectPath = join(packageDir, "pyproject.toml");
+  const pyproject = readFileSync(pyprojectPath, "utf8");
+  const match = pyproject.match(/^version = "([^"]+)"$/m);
+  if (!match) {
+    throw new Error(`Could not read project version from ${pyprojectPath}`);
+  }
+  return match[1];
 }
 
 function assertOrder({ source, filePath, anchor, first, second }) {

--- a/scripts/generate-python.mjs
+++ b/scripts/generate-python.mjs
@@ -48,6 +48,7 @@ for (const surface of surfaces) {
   const packageDir = join(root, "packages", "python", surface.name);
   const generatedRoot = join(outputRoot, surface.name);
   const inputSpec = surface.tags ? writeFilteredSpec(surface) : join(root, surface.spec);
+  const packageVersion = readProjectVersion(packageDir);
 
   run("pnpm", [
     "openapi-generator-cli",
@@ -60,7 +61,7 @@ for (const surface of surfaces) {
     generatedRoot,
     "-t",
     templateDir,
-    `--additional-properties=packageName=${surface.packageName},projectName=${surface.projectName},packageVersion=1.0.0,generateSourceCodeOnly=true,hideGenerationTimestamp=true`,
+    `--additional-properties=packageName=${surface.packageName},projectName=${surface.projectName},packageVersion=${packageVersion},generateSourceCodeOnly=true,hideGenerationTimestamp=true`,
     "--global-property=models,supportingFiles,apis,apiTests=false,modelTests=false,apiDocs=false,modelDocs=false",
   ]);
 
@@ -71,6 +72,16 @@ for (const surface of surfaces) {
 }
 
 console.log("Generated Python SDK packages");
+
+function readProjectVersion(packageDir) {
+  const pyprojectPath = join(packageDir, "pyproject.toml");
+  const pyproject = readFileSync(pyprojectPath, "utf8");
+  const match = pyproject.match(/^version = "([^"]+)"$/m);
+  if (!match) {
+    throw new Error(`Could not read project version from ${pyprojectPath}`);
+  }
+  return match[1];
+}
 
 function writeFilteredSpec(surface) {
   const source = JSON.parse(readFileSync(join(root, surface.spec), "utf8"));


### PR DESCRIPTION
## Summary
- read generated Python package versions from each package pyproject.toml during codegen
- add a Python generated-version staleness check so release bumps cannot drift again
- commit regenerated Python metadata for package version/User-Agent values

## Verification
- pnpm verify:sdk-staleness
- pnpm drift:check
- pnpm build
- diffray review --executor claude-cli --severity critical,high (No critical, high issues found; security-scan timed out internally and was excluded by diffray)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR keeps generated Python package versions aligned with each package manifest. It changes:

- Reads each generated Python package version from its `pyproject.toml` during codegen.
- Passes that version into OpenAPI Generator instead of using a hard-coded value.
- Adds Python staleness checks for `__version__`, User-Agent, and debug report package versions.
- Regenerates sending, mailbox, and management Python metadata to use `1.0.1`.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (2): Last reviewed commit: ["fix: keep generated python package versi..."](https://github.com/sendmux/sendmux-sdk/commit/8393149def46cab040e093931817ba979870055b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38043666)</sub>

<!-- /greptile_comment -->