### PR TITLE
fix(python): derive generated runtime version dynamically

### DIFF
--- a/packages/python/mailbox/sendmux_mailbox/api_client.py
+++ b/packages/python/mailbox/sendmux_mailbox/api_client.py
@@ -26,6 +26,9 @@ from urllib.parse import quote
 from typing import Tuple, Optional, List, Dict, Union
 from pydantic import SecretStr
 
+from importlib.metadata import PackageNotFoundError, version as _distribution_version
+from pathlib import Path
+
 from sendmux_mailbox.configuration import Configuration
 from sendmux_mailbox.api_response import ApiResponse, T as ApiResponseT
 import sendmux_mailbox.models
@@ -41,6 +44,19 @@ from sendmux_mailbox.exceptions import (
 )
 
 RequestSerialized = Tuple[str, str, Dict[str, str], Optional[str], List[str]]
+
+
+def _sdk_package_version() -> str:
+    try:
+        return _distribution_version("sendmux-mailbox")
+    except PackageNotFoundError:
+        init_source = Path(__file__).with_name("__init__.py").read_text(encoding="utf-8")
+        version_prefix = '__version__ = "'
+        for line in init_source.splitlines():
+            if line.startswith(version_prefix) and line.endswith('"'):
+                return line[len(version_prefix) : -1]
+        raise RuntimeError("Could not read sendmux-mailbox package version") from None
+
 
 class ApiClient:
     """Generic API client for OpenAPI client library builds.
@@ -91,7 +107,7 @@ class ApiClient:
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = 'OpenAPI-Generator/1.0.1/python'
+        self.user_agent = f'OpenAPI-Generator/{_sdk_package_version()}/python'
         self.client_side_validation = configuration.client_side_validation
 
     def __enter__(self):

--- a/packages/python/mailbox/sendmux_mailbox/api_client.py
+++ b/packages/python/mailbox/sendmux_mailbox/api_client.py
@@ -47,14 +47,16 @@ RequestSerialized = Tuple[str, str, Dict[str, str], Optional[str], List[str]]
 
 
 def _sdk_package_version() -> str:
+    init_path = Path(__file__).with_name("__init__.py")
+    version_prefix = '__version__ = "'
+    if init_path.exists():
+        for line in init_path.read_text(encoding="utf-8").splitlines():
+            if line.startswith(version_prefix) and line.endswith('"'):
+                return line[len(version_prefix) : -1]
+
     try:
         return _distribution_version("sendmux-mailbox")
     except PackageNotFoundError:
-        init_source = Path(__file__).with_name("__init__.py").read_text(encoding="utf-8")
-        version_prefix = '__version__ = "'
-        for line in init_source.splitlines():
-            if line.startswith(version_prefix) and line.endswith('"'):
-                return line[len(version_prefix) : -1]
         raise RuntimeError("Could not read sendmux-mailbox package version") from None
 
 

--- a/packages/python/mailbox/sendmux_mailbox/configuration.py
+++ b/packages/python/mailbox/sendmux_mailbox/configuration.py
@@ -11,6 +11,8 @@
 
 
 import copy
+from importlib.metadata import PackageNotFoundError, version as _distribution_version
+from pathlib import Path
 import http.client as httplib
 import logging
 from logging import FileHandler
@@ -29,6 +31,19 @@ JSON_SCHEMA_VALIDATION_KEYWORDS = {
 }
 
 ServerVariablesT = Dict[str, str]
+
+
+def _sdk_package_version() -> str:
+    try:
+        return _distribution_version("sendmux-mailbox")
+    except PackageNotFoundError:
+        init_source = Path(__file__).with_name("__init__.py").read_text(encoding="utf-8")
+        version_prefix = '__version__ = "'
+        for line in init_source.splitlines():
+            if line.startswith(version_prefix) and line.endswith('"'):
+                return line[len(version_prefix) : -1]
+        raise RuntimeError("Could not read sendmux-mailbox package version") from None
+
 
 GenericAuthSetting = TypedDict(
     "GenericAuthSetting",
@@ -534,8 +549,8 @@ class Configuration:
                "OS: {env}\n"\
                "Python Version: {pyversion}\n"\
                "Version of the API: 1.0.0\n"\
-               "SDK Package Version: 1.0.1".\
-               format(env=sys.platform, pyversion=sys.version)
+               "SDK Package Version: {sdk_package_version}".\
+               format(env=sys.platform, pyversion=sys.version, sdk_package_version=_sdk_package_version())
 
     def get_host_settings(self) -> List[HostSetting]:
         """Gets an array of host settings

--- a/packages/python/mailbox/sendmux_mailbox/configuration.py
+++ b/packages/python/mailbox/sendmux_mailbox/configuration.py
@@ -34,14 +34,16 @@ ServerVariablesT = Dict[str, str]
 
 
 def _sdk_package_version() -> str:
+    init_path = Path(__file__).with_name("__init__.py")
+    version_prefix = '__version__ = "'
+    if init_path.exists():
+        for line in init_path.read_text(encoding="utf-8").splitlines():
+            if line.startswith(version_prefix) and line.endswith('"'):
+                return line[len(version_prefix) : -1]
+
     try:
         return _distribution_version("sendmux-mailbox")
     except PackageNotFoundError:
-        init_source = Path(__file__).with_name("__init__.py").read_text(encoding="utf-8")
-        version_prefix = '__version__ = "'
-        for line in init_source.splitlines():
-            if line.startswith(version_prefix) and line.endswith('"'):
-                return line[len(version_prefix) : -1]
         raise RuntimeError("Could not read sendmux-mailbox package version") from None
 
 

--- a/packages/python/management/sendmux_management/api_client.py
+++ b/packages/python/management/sendmux_management/api_client.py
@@ -47,14 +47,16 @@ RequestSerialized = Tuple[str, str, Dict[str, str], Optional[str], List[str]]
 
 
 def _sdk_package_version() -> str:
+    init_path = Path(__file__).with_name("__init__.py")
+    version_prefix = '__version__ = "'
+    if init_path.exists():
+        for line in init_path.read_text(encoding="utf-8").splitlines():
+            if line.startswith(version_prefix) and line.endswith('"'):
+                return line[len(version_prefix) : -1]
+
     try:
         return _distribution_version("sendmux-management")
     except PackageNotFoundError:
-        init_source = Path(__file__).with_name("__init__.py").read_text(encoding="utf-8")
-        version_prefix = '__version__ = "'
-        for line in init_source.splitlines():
-            if line.startswith(version_prefix) and line.endswith('"'):
-                return line[len(version_prefix) : -1]
         raise RuntimeError("Could not read sendmux-management package version") from None
 
 

--- a/packages/python/management/sendmux_management/api_client.py
+++ b/packages/python/management/sendmux_management/api_client.py
@@ -26,6 +26,9 @@ from urllib.parse import quote
 from typing import Tuple, Optional, List, Dict, Union
 from pydantic import SecretStr
 
+from importlib.metadata import PackageNotFoundError, version as _distribution_version
+from pathlib import Path
+
 from sendmux_management.configuration import Configuration
 from sendmux_management.api_response import ApiResponse, T as ApiResponseT
 import sendmux_management.models
@@ -41,6 +44,19 @@ from sendmux_management.exceptions import (
 )
 
 RequestSerialized = Tuple[str, str, Dict[str, str], Optional[str], List[str]]
+
+
+def _sdk_package_version() -> str:
+    try:
+        return _distribution_version("sendmux-management")
+    except PackageNotFoundError:
+        init_source = Path(__file__).with_name("__init__.py").read_text(encoding="utf-8")
+        version_prefix = '__version__ = "'
+        for line in init_source.splitlines():
+            if line.startswith(version_prefix) and line.endswith('"'):
+                return line[len(version_prefix) : -1]
+        raise RuntimeError("Could not read sendmux-management package version") from None
+
 
 class ApiClient:
     """Generic API client for OpenAPI client library builds.
@@ -91,7 +107,7 @@ class ApiClient:
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = 'OpenAPI-Generator/1.0.1/python'
+        self.user_agent = f'OpenAPI-Generator/{_sdk_package_version()}/python'
         self.client_side_validation = configuration.client_side_validation
 
     def __enter__(self):

--- a/packages/python/management/sendmux_management/configuration.py
+++ b/packages/python/management/sendmux_management/configuration.py
@@ -34,14 +34,16 @@ ServerVariablesT = Dict[str, str]
 
 
 def _sdk_package_version() -> str:
+    init_path = Path(__file__).with_name("__init__.py")
+    version_prefix = '__version__ = "'
+    if init_path.exists():
+        for line in init_path.read_text(encoding="utf-8").splitlines():
+            if line.startswith(version_prefix) and line.endswith('"'):
+                return line[len(version_prefix) : -1]
+
     try:
         return _distribution_version("sendmux-management")
     except PackageNotFoundError:
-        init_source = Path(__file__).with_name("__init__.py").read_text(encoding="utf-8")
-        version_prefix = '__version__ = "'
-        for line in init_source.splitlines():
-            if line.startswith(version_prefix) and line.endswith('"'):
-                return line[len(version_prefix) : -1]
         raise RuntimeError("Could not read sendmux-management package version") from None
 
 

--- a/packages/python/management/sendmux_management/configuration.py
+++ b/packages/python/management/sendmux_management/configuration.py
@@ -11,6 +11,8 @@
 
 
 import copy
+from importlib.metadata import PackageNotFoundError, version as _distribution_version
+from pathlib import Path
 import http.client as httplib
 import logging
 from logging import FileHandler
@@ -29,6 +31,19 @@ JSON_SCHEMA_VALIDATION_KEYWORDS = {
 }
 
 ServerVariablesT = Dict[str, str]
+
+
+def _sdk_package_version() -> str:
+    try:
+        return _distribution_version("sendmux-management")
+    except PackageNotFoundError:
+        init_source = Path(__file__).with_name("__init__.py").read_text(encoding="utf-8")
+        version_prefix = '__version__ = "'
+        for line in init_source.splitlines():
+            if line.startswith(version_prefix) and line.endswith('"'):
+                return line[len(version_prefix) : -1]
+        raise RuntimeError("Could not read sendmux-management package version") from None
+
 
 GenericAuthSetting = TypedDict(
     "GenericAuthSetting",
@@ -534,8 +549,8 @@ class Configuration:
                "OS: {env}\n"\
                "Python Version: {pyversion}\n"\
                "Version of the API: 1.0.0\n"\
-               "SDK Package Version: 1.0.1".\
-               format(env=sys.platform, pyversion=sys.version)
+               "SDK Package Version: {sdk_package_version}".\
+               format(env=sys.platform, pyversion=sys.version, sdk_package_version=_sdk_package_version())
 
     def get_host_settings(self) -> List[HostSetting]:
         """Gets an array of host settings

--- a/packages/python/sending/sendmux_sending/api_client.py
+++ b/packages/python/sending/sendmux_sending/api_client.py
@@ -26,6 +26,9 @@ from urllib.parse import quote
 from typing import Tuple, Optional, List, Dict, Union
 from pydantic import SecretStr
 
+from importlib.metadata import PackageNotFoundError, version as _distribution_version
+from pathlib import Path
+
 from sendmux_sending.configuration import Configuration
 from sendmux_sending.api_response import ApiResponse, T as ApiResponseT
 import sendmux_sending.models
@@ -41,6 +44,19 @@ from sendmux_sending.exceptions import (
 )
 
 RequestSerialized = Tuple[str, str, Dict[str, str], Optional[str], List[str]]
+
+
+def _sdk_package_version() -> str:
+    try:
+        return _distribution_version("sendmux-sending")
+    except PackageNotFoundError:
+        init_source = Path(__file__).with_name("__init__.py").read_text(encoding="utf-8")
+        version_prefix = '__version__ = "'
+        for line in init_source.splitlines():
+            if line.startswith(version_prefix) and line.endswith('"'):
+                return line[len(version_prefix) : -1]
+        raise RuntimeError("Could not read sendmux-sending package version") from None
+
 
 class ApiClient:
     """Generic API client for OpenAPI client library builds.
@@ -91,7 +107,7 @@ class ApiClient:
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = 'OpenAPI-Generator/1.0.1/python'
+        self.user_agent = f'OpenAPI-Generator/{_sdk_package_version()}/python'
         self.client_side_validation = configuration.client_side_validation
 
     def __enter__(self):

--- a/packages/python/sending/sendmux_sending/api_client.py
+++ b/packages/python/sending/sendmux_sending/api_client.py
@@ -47,14 +47,16 @@ RequestSerialized = Tuple[str, str, Dict[str, str], Optional[str], List[str]]
 
 
 def _sdk_package_version() -> str:
+    init_path = Path(__file__).with_name("__init__.py")
+    version_prefix = '__version__ = "'
+    if init_path.exists():
+        for line in init_path.read_text(encoding="utf-8").splitlines():
+            if line.startswith(version_prefix) and line.endswith('"'):
+                return line[len(version_prefix) : -1]
+
     try:
         return _distribution_version("sendmux-sending")
     except PackageNotFoundError:
-        init_source = Path(__file__).with_name("__init__.py").read_text(encoding="utf-8")
-        version_prefix = '__version__ = "'
-        for line in init_source.splitlines():
-            if line.startswith(version_prefix) and line.endswith('"'):
-                return line[len(version_prefix) : -1]
         raise RuntimeError("Could not read sendmux-sending package version") from None
 
 

--- a/packages/python/sending/sendmux_sending/configuration.py
+++ b/packages/python/sending/sendmux_sending/configuration.py
@@ -11,6 +11,8 @@
 
 
 import copy
+from importlib.metadata import PackageNotFoundError, version as _distribution_version
+from pathlib import Path
 import http.client as httplib
 import logging
 from logging import FileHandler
@@ -29,6 +31,19 @@ JSON_SCHEMA_VALIDATION_KEYWORDS = {
 }
 
 ServerVariablesT = Dict[str, str]
+
+
+def _sdk_package_version() -> str:
+    try:
+        return _distribution_version("sendmux-sending")
+    except PackageNotFoundError:
+        init_source = Path(__file__).with_name("__init__.py").read_text(encoding="utf-8")
+        version_prefix = '__version__ = "'
+        for line in init_source.splitlines():
+            if line.startswith(version_prefix) and line.endswith('"'):
+                return line[len(version_prefix) : -1]
+        raise RuntimeError("Could not read sendmux-sending package version") from None
+
 
 GenericAuthSetting = TypedDict(
     "GenericAuthSetting",
@@ -533,8 +548,8 @@ class Configuration:
                "OS: {env}\n"\
                "Python Version: {pyversion}\n"\
                "Version of the API: 1.0.0\n"\
-               "SDK Package Version: 1.0.1".\
-               format(env=sys.platform, pyversion=sys.version)
+               "SDK Package Version: {sdk_package_version}".\
+               format(env=sys.platform, pyversion=sys.version, sdk_package_version=_sdk_package_version())
 
     def get_host_settings(self) -> List[HostSetting]:
         """Gets an array of host settings

--- a/packages/python/sending/sendmux_sending/configuration.py
+++ b/packages/python/sending/sendmux_sending/configuration.py
@@ -34,14 +34,16 @@ ServerVariablesT = Dict[str, str]
 
 
 def _sdk_package_version() -> str:
+    init_path = Path(__file__).with_name("__init__.py")
+    version_prefix = '__version__ = "'
+    if init_path.exists():
+        for line in init_path.read_text(encoding="utf-8").splitlines():
+            if line.startswith(version_prefix) and line.endswith('"'):
+                return line[len(version_prefix) : -1]
+
     try:
         return _distribution_version("sendmux-sending")
     except PackageNotFoundError:
-        init_source = Path(__file__).with_name("__init__.py").read_text(encoding="utf-8")
-        version_prefix = '__version__ = "'
-        for line in init_source.splitlines():
-            if line.startswith(version_prefix) and line.endswith('"'):
-                return line[len(version_prefix) : -1]
         raise RuntimeError("Could not read sendmux-sending package version") from None
 
 

--- a/packages/python/tests/test_generated_runtime_versions.py
+++ b/packages/python/tests/test_generated_runtime_versions.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import importlib
+from importlib.metadata import version
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("distribution_name", "package_name"),
+    [
+        ("sendmux-sending", "sendmux_sending"),
+        ("sendmux-mailbox", "sendmux_mailbox"),
+        ("sendmux-management", "sendmux_management"),
+    ],
+)
+def test_generated_runtime_versions_follow_distribution_metadata(
+    distribution_name: str,
+    package_name: str,
+) -> None:
+    expected = version(distribution_name)
+    package = importlib.import_module(package_name)
+    api_client = importlib.import_module(f"{package_name}.api_client")
+    configuration = importlib.import_module(f"{package_name}.configuration")
+
+    assert package.__version__ == expected
+    assert api_client.ApiClient(configuration=configuration.Configuration()).user_agent == (
+        f"OpenAPI-Generator/{expected}/python"
+    )
+    assert f"SDK Package Version: {expected}" in configuration.Configuration().to_debug_report()

--- a/packages/python/tests/test_generated_runtime_versions.py
+++ b/packages/python/tests/test_generated_runtime_versions.py
@@ -28,3 +28,33 @@ def test_generated_runtime_versions_follow_distribution_metadata(
         f"OpenAPI-Generator/{expected}/python"
     )
     assert f"SDK Package Version: {expected}" in configuration.Configuration().to_debug_report()
+
+
+@pytest.mark.parametrize(
+    ("distribution_name", "package_name"),
+    [
+        ("sendmux-sending", "sendmux_sending"),
+        ("sendmux-mailbox", "sendmux_mailbox"),
+        ("sendmux-management", "sendmux_management"),
+    ],
+)
+def test_generated_runtime_versions_prefer_imported_source(
+    monkeypatch: pytest.MonkeyPatch,
+    distribution_name: str,
+    package_name: str,
+) -> None:
+    package = importlib.import_module(package_name)
+    api_client = importlib.import_module(f"{package_name}.api_client")
+    configuration = importlib.import_module(f"{package_name}.configuration")
+
+    def stale_distribution_version(name: str) -> str:
+        assert name == distribution_name
+        return "0.0.0"
+
+    monkeypatch.setattr(api_client, "_distribution_version", stale_distribution_version)
+    monkeypatch.setattr(configuration, "_distribution_version", stale_distribution_version)
+
+    assert api_client.ApiClient(configuration=configuration.Configuration()).user_agent == (
+        f"OpenAPI-Generator/{package.__version__}/python"
+    )
+    assert f"SDK Package Version: {package.__version__}" in configuration.Configuration().to_debug_report()

--- a/scripts/check-python.mjs
+++ b/scripts/check-python.mjs
@@ -135,24 +135,26 @@ function checkGeneratedPackageVersions() {
       filePath: join(generatedPackage.moduleDir, "api_client.py"),
       expected: [
         "from importlib.metadata import PackageNotFoundError, version as _distribution_version",
-        `return _distribution_version("${generatedPackage.distributionName}")`,
+        'init_path = Path(__file__).with_name("__init__.py")',
         'version_prefix = \'__version__ = "\'',
         "return line[len(version_prefix) : -1]",
+        `return _distribution_version("${generatedPackage.distributionName}")`,
         "self.user_agent = f'OpenAPI-Generator/{_sdk_package_version()}/python'",
       ],
-      forbiddenPattern: /OpenAPI-Generator\/\d+\.\d+\.\d+\/python/,
+      forbiddenPattern: /OpenAPI-Generator\/(?!\{_sdk_package_version\(\)\})[^/]+\/python/,
     });
     assertGeneratedVersionReference({
       filePath: join(generatedPackage.moduleDir, "configuration.py"),
       expected: [
         "from importlib.metadata import PackageNotFoundError, version as _distribution_version",
-        `return _distribution_version("${generatedPackage.distributionName}")`,
+        'init_path = Path(__file__).with_name("__init__.py")',
         'version_prefix = \'__version__ = "\'',
         "return line[len(version_prefix) : -1]",
+        `return _distribution_version("${generatedPackage.distributionName}")`,
         '"SDK Package Version: {sdk_package_version}".\\',
         "sdk_package_version=_sdk_package_version()",
       ],
-      forbiddenPattern: /SDK Package Version: \d+\.\d+\.\d+/,
+      forbiddenPattern: /SDK Package Version: (?!\{sdk_package_version\})[^"]+/,
     });
   }
 }

--- a/scripts/check-python.mjs
+++ b/scripts/check-python.mjs
@@ -109,14 +109,17 @@ function checkGeneratedPackageVersions() {
     {
       packageDir: join(root, "packages", "python", "sending"),
       moduleDir: join(root, "packages", "python", "sending", "sendmux_sending"),
+      distributionName: "sendmux-sending",
     },
     {
       packageDir: join(root, "packages", "python", "mailbox"),
       moduleDir: join(root, "packages", "python", "mailbox", "sendmux_mailbox"),
+      distributionName: "sendmux-mailbox",
     },
     {
       packageDir: join(root, "packages", "python", "management"),
       moduleDir: join(root, "packages", "python", "management", "sendmux_management"),
+      distributionName: "sendmux-management",
     },
   ];
 
@@ -128,17 +131,28 @@ function checkGeneratedPackageVersions() {
       label: "__version__",
       expected: pyprojectVersion,
     });
-    assertGeneratedVersion({
+    assertGeneratedVersionReference({
       filePath: join(generatedPackage.moduleDir, "api_client.py"),
-      pattern: /self\.user_agent = 'OpenAPI-Generator\/([^/']+)\/python'/,
-      label: "User-Agent package version",
-      expected: pyprojectVersion,
+      expected: [
+        "from importlib.metadata import PackageNotFoundError, version as _distribution_version",
+        `return _distribution_version("${generatedPackage.distributionName}")`,
+        'version_prefix = \'__version__ = "\'',
+        "return line[len(version_prefix) : -1]",
+        "self.user_agent = f'OpenAPI-Generator/{_sdk_package_version()}/python'",
+      ],
+      forbiddenPattern: /OpenAPI-Generator\/\d+\.\d+\.\d+\/python/,
     });
-    assertGeneratedVersion({
+    assertGeneratedVersionReference({
       filePath: join(generatedPackage.moduleDir, "configuration.py"),
-      pattern: /"SDK Package Version: ([^"]+)"/,
-      label: "debug-report SDK package version",
-      expected: pyprojectVersion,
+      expected: [
+        "from importlib.metadata import PackageNotFoundError, version as _distribution_version",
+        `return _distribution_version("${generatedPackage.distributionName}")`,
+        'version_prefix = \'__version__ = "\'',
+        "return line[len(version_prefix) : -1]",
+        '"SDK Package Version: {sdk_package_version}".\\',
+        "sdk_package_version=_sdk_package_version()",
+      ],
+      forbiddenPattern: /SDK Package Version: \d+\.\d+\.\d+/,
     });
   }
 }
@@ -148,6 +162,19 @@ function assertGeneratedVersion({ filePath, pattern, label, expected }) {
   const actual = source.match(pattern)?.[1];
   if (actual !== expected) {
     throw new Error(`${filePath} has ${label} ${actual ?? "<missing>"} but pyproject.toml has ${expected}`);
+  }
+}
+
+function assertGeneratedVersionReference({ filePath, expected, forbiddenPattern }) {
+  const source = readFileSync(filePath, "utf8");
+  for (const snippet of expected) {
+    if (!source.includes(snippet)) {
+      throw new Error(`${filePath} is missing generated runtime version reference: ${snippet}`);
+    }
+  }
+  const forbidden = source.match(forbiddenPattern)?.[0];
+  if (forbidden) {
+    throw new Error(`${filePath} still hardcodes generated runtime package version: ${forbidden}`);
   }
 }
 

--- a/scripts/generate-python.mjs
+++ b/scripts/generate-python.mjs
@@ -68,6 +68,7 @@ for (const surface of surfaces) {
   rmSync(join(packageDir, surface.packageName), { force: true, recursive: true });
   cpSync(join(generatedRoot, surface.packageName), join(packageDir, surface.packageName), { recursive: true });
   writeSurfaceClient(surface);
+  linkGeneratedRuntimeVersion(surface, packageDir);
   normalizePythonFiles(join(packageDir, surface.packageName));
 }
 
@@ -299,6 +300,63 @@ from ${surface.packageName}.client import (
 )
 `,
   );
+}
+
+function linkGeneratedRuntimeVersion(surface, packageDir) {
+  const packageRoot = join(packageDir, surface.packageName);
+  const apiClientPath = join(packageRoot, "api_client.py");
+  const configurationPath = join(packageRoot, "configuration.py");
+
+  let apiClient = readFileSync(apiClientPath, "utf8");
+  apiClient = replaceOnce({
+    source: apiClient,
+    filePath: apiClientPath,
+    from: "from pydantic import SecretStr\n\n",
+    to: "from pydantic import SecretStr\n\nfrom importlib.metadata import PackageNotFoundError, version as _distribution_version\nfrom pathlib import Path\n\n",
+  });
+  apiClient = replaceOnce({
+    source: apiClient,
+    filePath: apiClientPath,
+    from: "RequestSerialized = Tuple[str, str, Dict[str, str], Optional[str], List[str]]\n\nclass ApiClient:",
+    to: `RequestSerialized = Tuple[str, str, Dict[str, str], Optional[str], List[str]]\n\n\ndef _sdk_package_version() -> str:\n    try:\n        return _distribution_version("${surface.projectName}")\n    except PackageNotFoundError:\n        init_source = Path(__file__).with_name("__init__.py").read_text(encoding="utf-8")\n        version_prefix = '__version__ = "'\n        for line in init_source.splitlines():\n            if line.startswith(version_prefix) and line.endswith('"'):\n                return line[len(version_prefix) : -1]\n        raise RuntimeError("Could not read ${surface.projectName} package version") from None\n\n\nclass ApiClient:`,
+  });
+  apiClient = apiClient.replace(
+    /self\.user_agent = 'OpenAPI-Generator\/[^/']+\/python'/,
+    "self.user_agent = f'OpenAPI-Generator/{_sdk_package_version()}/python'",
+  );
+  writeFileSync(apiClientPath, apiClient);
+
+  let configuration = readFileSync(configurationPath, "utf8");
+  configuration = replaceOnce({
+    source: configuration,
+    filePath: configurationPath,
+    from: "import copy\n",
+    to: "import copy\nfrom importlib.metadata import PackageNotFoundError, version as _distribution_version\nfrom pathlib import Path\n",
+  });
+  configuration = replaceOnce({
+    source: configuration,
+    filePath: configurationPath,
+    from: "ServerVariablesT = Dict[str, str]\n\nGenericAuthSetting",
+    to: `ServerVariablesT = Dict[str, str]\n\n\ndef _sdk_package_version() -> str:\n    try:\n        return _distribution_version("${surface.projectName}")\n    except PackageNotFoundError:\n        init_source = Path(__file__).with_name("__init__.py").read_text(encoding="utf-8")\n        version_prefix = '__version__ = "'\n        for line in init_source.splitlines():\n            if line.startswith(version_prefix) and line.endswith('"'):\n                return line[len(version_prefix) : -1]\n        raise RuntimeError("Could not read ${surface.projectName} package version") from None\n\n\nGenericAuthSetting`,
+  });
+  configuration = configuration.replace(
+    /"SDK Package Version: [^"]+"\.\\/,
+    '"SDK Package Version: {sdk_package_version}".\\',
+  );
+  configuration = replaceOnce({
+    source: configuration,
+    filePath: configurationPath,
+    from: "format(env=sys.platform, pyversion=sys.version)",
+    to: "format(env=sys.platform, pyversion=sys.version, sdk_package_version=_sdk_package_version())",
+  });
+  writeFileSync(configurationPath, configuration);
+}
+
+function replaceOnce({ source, filePath, from, to }) {
+  if (!source.includes(from)) {
+    throw new Error(`Could not find expected generated snippet in ${filePath}`);
+  }
+  return source.replace(from, to);
 }
 
 function run(command, args) {

--- a/scripts/generate-python.mjs
+++ b/scripts/generate-python.mjs
@@ -318,12 +318,15 @@ function linkGeneratedRuntimeVersion(surface, packageDir) {
     source: apiClient,
     filePath: apiClientPath,
     from: "RequestSerialized = Tuple[str, str, Dict[str, str], Optional[str], List[str]]\n\nclass ApiClient:",
-    to: `RequestSerialized = Tuple[str, str, Dict[str, str], Optional[str], List[str]]\n\n\ndef _sdk_package_version() -> str:\n    try:\n        return _distribution_version("${surface.projectName}")\n    except PackageNotFoundError:\n        init_source = Path(__file__).with_name("__init__.py").read_text(encoding="utf-8")\n        version_prefix = '__version__ = "'\n        for line in init_source.splitlines():\n            if line.startswith(version_prefix) and line.endswith('"'):\n                return line[len(version_prefix) : -1]\n        raise RuntimeError("Could not read ${surface.projectName} package version") from None\n\n\nclass ApiClient:`,
+    to: `RequestSerialized = Tuple[str, str, Dict[str, str], Optional[str], List[str]]\n\n\ndef _sdk_package_version() -> str:\n    init_path = Path(__file__).with_name("__init__.py")\n    version_prefix = '__version__ = "'\n    if init_path.exists():\n        for line in init_path.read_text(encoding="utf-8").splitlines():\n            if line.startswith(version_prefix) and line.endswith('"'):\n                return line[len(version_prefix) : -1]\n\n    try:\n        return _distribution_version("${surface.projectName}")\n    except PackageNotFoundError:\n        raise RuntimeError("Could not read ${surface.projectName} package version") from None\n\n\nclass ApiClient:`,
   });
-  apiClient = apiClient.replace(
-    /self\.user_agent = 'OpenAPI-Generator\/[^/']+\/python'/,
+  apiClient = replacePatternOnce({
+    source: apiClient,
+    filePath: apiClientPath,
+    pattern: /self\.user_agent = ['"]OpenAPI-Generator\/[^/'"]+\/python['"]/,
+    to:
     "self.user_agent = f'OpenAPI-Generator/{_sdk_package_version()}/python'",
-  );
+  });
   writeFileSync(apiClientPath, apiClient);
 
   let configuration = readFileSync(configurationPath, "utf8");
@@ -337,12 +340,14 @@ function linkGeneratedRuntimeVersion(surface, packageDir) {
     source: configuration,
     filePath: configurationPath,
     from: "ServerVariablesT = Dict[str, str]\n\nGenericAuthSetting",
-    to: `ServerVariablesT = Dict[str, str]\n\n\ndef _sdk_package_version() -> str:\n    try:\n        return _distribution_version("${surface.projectName}")\n    except PackageNotFoundError:\n        init_source = Path(__file__).with_name("__init__.py").read_text(encoding="utf-8")\n        version_prefix = '__version__ = "'\n        for line in init_source.splitlines():\n            if line.startswith(version_prefix) and line.endswith('"'):\n                return line[len(version_prefix) : -1]\n        raise RuntimeError("Could not read ${surface.projectName} package version") from None\n\n\nGenericAuthSetting`,
+    to: `ServerVariablesT = Dict[str, str]\n\n\ndef _sdk_package_version() -> str:\n    init_path = Path(__file__).with_name("__init__.py")\n    version_prefix = '__version__ = "'\n    if init_path.exists():\n        for line in init_path.read_text(encoding="utf-8").splitlines():\n            if line.startswith(version_prefix) and line.endswith('"'):\n                return line[len(version_prefix) : -1]\n\n    try:\n        return _distribution_version("${surface.projectName}")\n    except PackageNotFoundError:\n        raise RuntimeError("Could not read ${surface.projectName} package version") from None\n\n\nGenericAuthSetting`,
   });
-  configuration = configuration.replace(
-    /"SDK Package Version: [^"]+"\.\\/,
-    '"SDK Package Version: {sdk_package_version}".\\',
-  );
+  configuration = replacePatternOnce({
+    source: configuration,
+    filePath: configurationPath,
+    pattern: /"SDK Package Version: [^"]+"\.\\/,
+    to: '"SDK Package Version: {sdk_package_version}".\\',
+  });
   configuration = replaceOnce({
     source: configuration,
     filePath: configurationPath,
@@ -357,6 +362,14 @@ function replaceOnce({ source, filePath, from, to }) {
     throw new Error(`Could not find expected generated snippet in ${filePath}`);
   }
   return source.replace(from, to);
+}
+
+function replacePatternOnce({ source, filePath, pattern, to }) {
+  const next = source.replace(pattern, to);
+  if (next === source) {
+    throw new Error(`Could not find expected generated pattern ${pattern} in ${filePath}`);
+  }
+  return next;
 }
 
 function run(command, args) {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the generated Python runtime version come from the package being used. It changes:

- Generated `ApiClient` user agents now call a runtime version helper.
- Generated debug reports now include the same dynamic package version.
- The helper prefers the adjacent `__init__.py` version, then falls back to installed distribution metadata.
- Python checks now verify the dynamic version wiring and reject remaining hardcoded runtime strings.
- Generation now fails when the expected user-agent or debug-report replacement cannot be applied.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/python/sending/sendmux_sending/api_client.py | User-Agent version now resolves from the imported package version helper. |
| packages/python/sending/sendmux_sending/configuration.py | Debug report version now uses the same dynamic package version helper. |
| scripts/generate-python.mjs | Python generation now injects dynamic version helpers and fails if key replacements are missing. |
| scripts/check-python.mjs | Python validation now checks for dynamic version references and broader hardcoded-version patterns. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(python): harden generated runtime ve..."](https://github.com/sendmux/sendmux-sdk/commit/02325ba09b68b472ddc1579b5ef7cb573e802720) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38052467)</sub>

<!-- /greptile_comment -->