### PR TITLE
fix(cli): add npm license metadata

### DIFF
--- a/packages/ts/cli/package.json
+++ b/packages/ts/cli/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@sendmux/cli",
   "version": "1.0.0",
+  "license": "MIT",
   "type": "module",
   "bin": {
     "sendmux": "./bin/run.js"

--- a/scripts/check-cli.mjs
+++ b/scripts/check-cli.mjs
@@ -8,6 +8,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 const cliPath = "packages/ts/cli/bin/run.js";
+const cliManifestPath = "packages/ts/cli/package.json";
 const operationsPath = "packages/ts/cli/src/generated/operations.ts";
 const operationRunnerPath = "packages/ts/cli/src/operation-runner.ts";
 const commandsDir = "packages/ts/cli/src/commands";
@@ -58,6 +59,7 @@ server.listen(0, "127.0.0.1");
 await once(server, "listening");
 
 try {
+  assertCliPackageMetadata();
   assertCliCommandCoverage();
   assertBinaryOperationRunnerGuard();
   await assertCliArrayParameterSupport();
@@ -431,6 +433,16 @@ function assertDeepEqual(actual, expected, message) {
 function assertCliSuccess(result, label) {
   if (result.status !== 0) {
     throw new Error(`${label} failed:\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  }
+}
+
+function assertCliPackageMetadata() {
+  const manifest = JSON.parse(readFileSync(cliManifestPath, "utf8"));
+  if (manifest.license !== "MIT") {
+    throw new Error('@sendmux/cli package.json must declare "license": "MIT" for npm package metadata');
+  }
+  if (manifest.repository?.directory !== "packages/ts/cli") {
+    throw new Error('@sendmux/cli package.json must point repository.directory at "packages/ts/cli"');
   }
 }
 


### PR DESCRIPTION
## Summary
- add `license: "MIT"` to `@sendmux/cli` package metadata
- assert CLI package metadata in `pnpm check:cli` so missing npm-facing metadata regresses visibly

## Verification
- `pnpm install --frozen-lockfile`
- pre-fix metadata assertion failed against `HEAD:packages/ts/cli/package.json` with `missing license`
- `pnpm check:cli`
- `node -p "require('./packages/ts/cli/package.json').license"`
- `git diff --check`
- `NPM_PUBLISH_DRY_RUN=true SENDMUX_NPM_PUBLISH_PACKAGES=packages/ts/cli pnpm publish:npm:ts`
- packed manifest check: `@sendmux/cli`, version `1.0.0`, license `MIT`, repository directory `packages/ts/cli`
- `pnpm build`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the missing `"license": "MIT"` field to `packages/ts/cli/package.json` and introduces a regression guard in `scripts/check-cli.mjs` that will catch the omission going forward.

- `packages/ts/cli/package.json`: one-line addition of `"license": "MIT"` alongside the pre-existing `repository` metadata.
- `scripts/check-cli.mjs`: new synchronous `assertCliPackageMetadata()` reads the manifest at check time and throws with a descriptive message if `license` is not `"MIT"` or `repository.directory` does not match `"packages/ts/cli"`. The assertion runs first in the `try` block, so failures are reported immediately before any CLI invocations, and the existing `finally` block ensures the test server and temp directory are still cleaned up correctly.

<h3>Confidence Score: 5/5</h3>

Safe to merge — one-line metadata addition with a matching regression guard in the check script.

Both changes are minimal and correct: package.json gets the missing license field, and check-cli.mjs adds a synchronous assertion that reads the manifest directly and fails fast with a clear error message. Optional chaining on repository?.directory handles the missing-field case cleanly, and the new assertion runs inside the existing try/finally so cleanup is always guaranteed.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ts/cli/package.json | Adds "license": "MIT" field — minimal, correct metadata fix for npm publishing. |
| scripts/check-cli.mjs | Adds assertCliPackageMetadata() that validates license and repository.directory; called first in the try block with proper cleanup guaranteed by the existing finally. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pnpm check:cli] --> B[ensureCliBuilt]
    B --> C[Start test HTTP server]
    C --> D[assertCliPackageMetadata NEW]
    D -->|license !== MIT| E[throw Error]
    D -->|repository.directory mismatch| E
    D -->|pass| F[assertCliCommandCoverage]
    F --> G[assertBinaryOperationRunnerGuard]
    G --> H[assertCliArrayParameterSupport]
    H --> I[CLI integration tests]
    I --> J[console.log: CLI gate checks passed]
    E --> K[finally: close server + rmSync tempHome]
    J --> K
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[pnpm check:cli] --> B[ensureCliBuilt]
    B --> C[Start test HTTP server]
    C --> D[assertCliPackageMetadata NEW]
    D -->|license !== MIT| E[throw Error]
    D -->|repository.directory mismatch| E
    D -->|pass| F[assertCliCommandCoverage]
    F --> G[assertBinaryOperationRunnerGuard]
    G --> H[assertCliArrayParameterSupport]
    H --> I[CLI integration tests]
    I --> J[console.log: CLI gate checks passed]
    E --> K[finally: close server + rmSync tempHome]
    J --> K
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): add npm license metadata"](https://github.com/sendmux/sendmux-sdk/commit/4c0a1ac7140817c25522c65e2b7485633dbde8f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38308903)</sub>

<!-- /greptile_comment -->