### PR TITLE
Add Homebrew tap release automation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -118,6 +118,13 @@ jobs:
           fi
           gh release upload "$tag" "${assets[@]}" --clobber
 
+      - name: Update Homebrew tap
+        if: ${{ contains(needs.release-please.outputs.paths_released, 'packages/ts/cli') }}
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          SENDMUX_HOMEBREW_TAP_REPO: Sendmux/homebrew-tap
+        run: node scripts/update-homebrew-tap.mjs
+
   recover-ts-cli-release:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.recover_ts_cli_version != '' }}
     runs-on: ubuntu-latest
@@ -202,6 +209,12 @@ jobs:
             exit 1
           fi
           gh release upload "$tag" "${assets[@]}" --clobber
+
+      - name: Update Homebrew tap
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          SENDMUX_HOMEBREW_TAP_REPO: Sendmux/homebrew-tap
+        run: node scripts/update-homebrew-tap.mjs
 
   publish-pypi:
     needs: release-please

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Official SDK, CLI, and MCP workspace for Sendmux.
 | npm | `@sendmux/management` | Management API | `smx_root_*` | `npm install @sendmux/management` | [`packages/ts/management`](packages/ts/management) |
 | npm | `@sendmux/sdk` | TypeScript umbrella package | surface-specific | `npm install @sendmux/sdk` | [`packages/ts/sdk`](packages/ts/sdk) |
 | npm | `@sendmux/cli` | `sendmux` CLI | command/profile-specific | `npm install -g @sendmux/cli` | [`packages/ts/cli`](packages/ts/cli) |
+| Homebrew | `sendmux` | `sendmux` CLI | command/profile-specific | `brew install sendmux/tap/sendmux` | [`Sendmux/homebrew-tap`](https://github.com/Sendmux/homebrew-tap) |
 | PyPI | `sendmux-core` | Shared Python helpers | n/a | `pip install sendmux-core` | [`packages/python/core`](packages/python/core) |
 | PyPI | `sendmux-sending` | Sending API | `smx_mbx_*` | `pip install sendmux-sending` | [`packages/python/sending`](packages/python/sending) |
 | PyPI | `sendmux-mailbox` | Mailbox API | `smx_mbx_*` | `pip install sendmux-mailbox` | [`packages/python/mailbox`](packages/python/mailbox) |
@@ -64,6 +65,7 @@ Use mailbox-scoped `smx_mbx_*` keys for Sending and Mailbox clients. Use root `s
 For command-line access, install the CLI:
 
 ```sh
+brew install sendmux/tap/sendmux
 npm install -g @sendmux/cli
 sendmux --help
 ```

--- a/scripts/update-homebrew-tap.mjs
+++ b/scripts/update-homebrew-tap.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const cliManifestPath = join(rootDir, "packages/ts/cli/package.json");
+const tapRepo = process.env.SENDMUX_HOMEBREW_TAP_REPO ?? "Sendmux/homebrew-tap";
+const baseBranch = process.env.SENDMUX_HOMEBREW_TAP_BASE_BRANCH ?? "main";
+const packageName = "@sendmux/cli";
+const cliManifest = JSON.parse(readFileSync(cliManifestPath, "utf8"));
+const version = cliManifest.version;
+const branch = process.env.SENDMUX_HOMEBREW_TAP_BRANCH ?? `homebrew/sendmux-v${version}`;
+const token = process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN;
+
+if (!token) {
+  throw new Error("Missing GH_TOKEN or GITHUB_TOKEN for Sendmux/homebrew-tap write access.");
+}
+
+let tapDir;
+
+await main();
+
+async function main() {
+  const tarballUrl = await npmViewWithRetry(`${packageName}@${version}`, "dist.tarball");
+  const sha256 = await sha256FromUrl(tarballUrl);
+  const tempDir = mkdtempSync(join(tmpdir(), "sendmux-homebrew-tap-"));
+  tapDir = join(tempDir, "tap");
+
+  try {
+    execFileSync("gh", ["auth", "setup-git"], { env: process.env, stdio: "inherit" });
+    execFileSync("gh", ["repo", "clone", tapRepo, tapDir, "--", "--depth=1"], {
+      env: process.env,
+      stdio: "inherit",
+    });
+    execFileSync("git", ["checkout", "-B", branch], { cwd: tapDir, stdio: "inherit" });
+    execFileSync("git", ["config", "user.name", "sendmux-release-bot"], {
+      cwd: tapDir,
+      stdio: "inherit",
+    });
+    execFileSync("git", ["config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com"], {
+      cwd: tapDir,
+      stdio: "inherit",
+    });
+
+    mkdirSync(join(tapDir, "Formula"), { recursive: true });
+    writeFileSync(join(tapDir, "Formula/sendmux.rb"), formulaFor({ sha256, tarballUrl, version }));
+
+    if (!git(["status", "--porcelain", "--", "Formula/sendmux.rb"])) {
+      console.log(`Homebrew formula already matches ${packageName}@${version}.`);
+      return;
+    }
+
+    execFileSync("git", ["add", "Formula/sendmux.rb"], { cwd: tapDir, stdio: "inherit" });
+    execFileSync("git", ["commit", "-m", `sendmux ${version}`], { cwd: tapDir, stdio: "inherit" });
+    execFileSync("git", ["push", "--force-with-lease", "origin", branch], {
+      cwd: tapDir,
+      stdio: "inherit",
+    });
+
+    const owner = tapRepo.split("/")[0];
+    const head = `${owner}:${branch}`;
+    const existingPrUrl = gh(
+      ["pr", "list", "--repo", tapRepo, "--base", baseBranch, "--head", head, "--state", "open", "--json", "url", "--jq", ".[0].url"],
+      { allowFailure: true },
+    );
+
+    if (existingPrUrl) {
+      console.log(`Homebrew tap PR already open: ${existingPrUrl}`);
+      return;
+    }
+
+    const body = [
+      `Updates the Sendmux Homebrew formula to ${packageName}@${version}.`,
+      "",
+      `- npm tarball: ${tarballUrl}`,
+      `- sha256: ${sha256}`,
+      "",
+      "Release workflow generated this PR after publishing the CLI package.",
+    ].join("\n");
+
+    const prUrl = gh([
+      "pr",
+      "create",
+      "--repo",
+      tapRepo,
+      "--base",
+      baseBranch,
+      "--head",
+      head,
+      "--title",
+      `Update sendmux formula to ${version}`,
+      "--body",
+      body,
+    ]);
+    console.log(`Homebrew tap PR opened: ${prUrl}`);
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+}
+
+async function npmViewWithRetry(pkg, field) {
+  let lastError;
+  for (let attempt = 1; attempt <= 6; attempt += 1) {
+    try {
+      return JSON.parse(execFileSync("npm", ["view", pkg, field, "--json"], { encoding: "utf8" }).trim());
+    } catch (error) {
+      lastError = error;
+      await sleep(attempt * 5000);
+    }
+  }
+  throw lastError;
+}
+
+async function sha256FromUrl(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to download npm tarball ${url}: ${response.status} ${response.statusText}`);
+  }
+  const bytes = Buffer.from(await response.arrayBuffer());
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function formulaFor({ sha256, tarballUrl, version }) {
+  return `class Sendmux < Formula
+  desc "Command-line access to Sendmux APIs"
+  homepage "https://docs.sendmux.ai/cli"
+  url "${tarballUrl}"
+  sha256 "${sha256}"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink libexec.glob("bin/*")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/sendmux --version")
+    assert_match "Sendmux", shell_output("#{bin}/sendmux --help")
+  end
+end
+`;
+}
+
+function gh(args, options = {}) {
+  return run("gh", args, options);
+}
+
+function git(args, options = {}) {
+  return run("git", args, { ...options, cwd: tapDir });
+}
+
+function run(cmd, args, options = {}) {
+  try {
+    return execFileSync(cmd, args, {
+      cwd: options.cwd,
+      encoding: "utf8",
+      env: process.env,
+      stdio: options.stdio ?? ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (error) {
+    if (options.allowFailure) {
+      return error.status ?? 1;
+    }
+    throw error;
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/scripts/update-homebrew-tap.mjs
+++ b/scripts/update-homebrew-tap.mjs
@@ -37,7 +37,11 @@ async function main() {
       env: process.env,
       stdio: "inherit",
     });
-    execFileSync("git", ["checkout", "-B", branch], { cwd: tapDir, stdio: "inherit" });
+    const hasRemoteBranch = fetchRemoteBranch(branch);
+    execFileSync("git", hasRemoteBranch ? ["checkout", "-B", branch, `origin/${branch}`] : ["checkout", "-B", branch], {
+      cwd: tapDir,
+      stdio: "inherit",
+    });
     execFileSync("git", ["config", "user.name", "sendmux-release-bot"], {
       cwd: tapDir,
       stdio: "inherit",
@@ -62,11 +66,9 @@ async function main() {
       stdio: "inherit",
     });
 
-    const owner = tapRepo.split("/")[0];
-    const head = `${owner}:${branch}`;
+    const head = branch;
     const existingPrUrl = gh(
-      ["pr", "list", "--repo", tapRepo, "--base", baseBranch, "--head", head, "--state", "open", "--json", "url", "--jq", ".[0].url"],
-      { allowFailure: true },
+      ["pr", "list", "--repo", tapRepo, "--base", baseBranch, "--head", head, "--state", "open", "--json", "url", "--jq", ".[0].url // empty"],
     );
 
     if (existingPrUrl) {
@@ -154,6 +156,18 @@ function gh(args, options = {}) {
 
 function git(args, options = {}) {
   return run("git", args, { ...options, cwd: tapDir });
+}
+
+function fetchRemoteBranch(branchName) {
+  try {
+    execFileSync("git", ["fetch", "origin", `refs/heads/${branchName}:refs/remotes/origin/${branchName}`], {
+      cwd: tapDir,
+      stdio: "inherit",
+    });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function run(cmd, args, options = {}) {

--- a/scripts/update-homebrew-tap.mjs
+++ b/scripts/update-homebrew-tap.mjs
@@ -130,7 +130,7 @@ async function sha256FromUrl(url) {
 function formulaFor({ sha256, tarballUrl, version }) {
   return `class Sendmux < Formula
   desc "Command-line access to Sendmux APIs"
-  homepage "https://docs.sendmux.ai/cli"
+  homepage "https://docs.sendmux.ai"
   url "${tarballUrl}"
   sha256 "${sha256}"
   license "MIT"


### PR DESCRIPTION
## Summary
- add a release helper that opens Sendmux/homebrew-tap formula update PRs after @sendmux/cli publishes
- wire the helper into normal CLI releases and recovery releases
- document Homebrew as a CLI install option in the SDK README

## Verification
- node --check scripts/update-homebrew-tap.mjs
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a Homebrew tap release automation script (`scripts/update-homebrew-tap.mjs`) and wires it into both the normal CLI release and the recovery workflow, along with documenting Homebrew as an install option in the README.

- The script clones `Sendmux/homebrew-tap`, writes a `Formula/sendmux.rb` generated from the npm tarball URL and SHA-256, commits and pushes a versioned branch, then opens (or skips if already open) a PR — with retry logic for npm propagation delays and an idempotency check on the formula content.
- The workflow integration correctly gates the Homebrew step on `packages/ts/cli` being included in the release, and uses a dedicated `HOMEBREW_TAP_TOKEN` secret for cross-repo write access.
- Two minor quality issues exist: the retry loop sleeps after the final failing attempt (wasted 30 s on failure), and the generated formula omits an explicit `version` field, relying on Homebrew to infer it from the tarball filename.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the automation is idempotent, the previous null-PR bug is correctly fixed, and the workflow integration is well-conditioned.

The script handles the main failure modes cleanly: retry for npm propagation, no-op when the formula is already up to date, and correct jq filtering to avoid false-positive PR-already-open exits. The two remaining issues (wasted sleep on the last retry, missing explicit version field in the formula) are both non-blocking quality nits that do not affect correctness in the happy path.

scripts/update-homebrew-tap.mjs — minor improvements possible in the retry loop and the generated formula template, but neither blocks the release automation from working correctly.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/update-homebrew-tap.mjs | New script that clones the homebrew-tap repo, writes a formula from the npm tarball URL + SHA256, commits and pushes a branch, then opens a PR. Logic is mostly sound after the jq // empty fix; two minor issues noted: wasted sleep after last retry attempt, and no explicit version field in the generated formula. |
| .github/workflows/release-please.yml | Adds Update Homebrew tap step to both publish-npm (gated on CLI path) and recover-ts-cli-release jobs, using HOMEBREW_TAP_TOKEN secret. Correctly conditioned and integrated. |
| README.md | Adds Homebrew install row to the package table and a brew command to the CLI install snippet. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant WF as GitHub Actions
    participant npm as npm Registry
    participant tap as Sendmux/homebrew-tap

    WF->>WF: Read version from packages/ts/cli/package.json
    WF->>npm: "npm view @sendmux/cli@{version} dist.tarball (with retry)"
    npm-->>WF: tarballUrl
    WF->>npm: fetch tarball for SHA-256
    npm-->>WF: sha256
    WF->>tap: "gh repo clone (depth=1)"
    WF->>tap: "git fetch origin homebrew/sendmux-v{version} (optional)"
    WF->>tap: "git checkout -B homebrew/sendmux-v{version}"
    WF->>tap: write Formula/sendmux.rb
    alt formula unchanged
        WF->>WF: log already matches, exit
    else formula changed
        WF->>tap: git commit + push --force-with-lease
        WF->>tap: gh pr list (check for open PR)
        alt PR already open
            WF->>WF: log PR URL, exit
        else no open PR
            WF->>tap: gh pr create
            tap-->>WF: PR URL
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant WF as GitHub Actions
    participant npm as npm Registry
    participant tap as Sendmux/homebrew-tap

    WF->>WF: Read version from packages/ts/cli/package.json
    WF->>npm: "npm view @sendmux/cli@{version} dist.tarball (with retry)"
    npm-->>WF: tarballUrl
    WF->>npm: fetch tarball for SHA-256
    npm-->>WF: sha256
    WF->>tap: "gh repo clone (depth=1)"
    WF->>tap: "git fetch origin homebrew/sendmux-v{version} (optional)"
    WF->>tap: "git checkout -B homebrew/sendmux-v{version}"
    WF->>tap: write Formula/sendmux.rb
    alt formula unchanged
        WF->>WF: log already matches, exit
    else formula changed
        WF->>tap: git commit + push --force-with-lease
        WF->>tap: gh pr list (check for open PR)
        alt PR already open
            WF->>WF: log PR URL, exit
        else no open PR
            WF->>tap: gh pr create
            tap-->>WF: PR URL
        end
    end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Use stable Homebrew formula homepage"](https://github.com/sendmux/sendmux-sdk/commit/ce859cdba14e9a0cfd727a0cb92e81e35c2eeb92) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38310959)</sub>

<!-- /greptile_comment -->