### PR TITLE
Fix SDK package metadata and Chocolatey PR tests

### DIFF
--- a/.github/workflows/chocolatey.yml
+++ b/.github/workflows/chocolatey.yml
@@ -13,6 +13,7 @@ on:
       - "scripts/cli-tarball-tools.mjs"
       - "scripts/pack-cli-tarballs.mjs"
       - "scripts/prepare-chocolatey-packages.mjs"
+      - "scripts/serve-static.mjs"
       - "scripts/test-chocolatey-asset-tools.mjs"
       - "scripts/test-chocolatey-workflow-order.mjs"
       - "scripts/test-cli-tarball-tools.mjs"
@@ -76,6 +77,7 @@ jobs:
 
       - name: Verify workflow helper scripts
         run: |
+          node --check scripts/serve-static.mjs
           pnpm test:windows-command-shims
           pnpm test:chocolatey-asset-tools
           pnpm test:chocolatey-workflow-order
@@ -110,7 +112,19 @@ jobs:
 
       - name: Generate Chocolatey packages
         shell: bash
-        run: node scripts/prepare-chocolatey-packages.mjs
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            asset="$(find packages/ts/cli/dist -maxdepth 1 -type f -name "sendmux-v*-win32-x64.zip" | sort | tail -n 1)"
+            if [ -z "$asset" ]; then
+              echo "No local Windows ZIP asset found for PR Chocolatey install test."
+              exit 1
+            fi
+            local_url="http://127.0.0.1:8765/$(basename "$asset")"
+            echo "SENDMUX_CHOCOLATEY_DOWNLOAD_URL=$local_url" >> "$GITHUB_ENV"
+            export SENDMUX_CHOCOLATEY_DOWNLOAD_URL="$local_url"
+          fi
+          node scripts/prepare-chocolatey-packages.mjs
 
       - name: Pack Chocolatey packages
         shell: powershell
@@ -144,15 +158,27 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           $source = Resolve-Path .tmp/chocolatey/pkg
+          $server = $null
 
-          choco install sendmux.portable --source "$source" -y --no-progress
-          sendmux --help
-          choco uninstall sendmux.portable -y --no-progress
+          if ('${{ github.event_name }}' -eq 'pull_request') {
+            $server = Start-Process -FilePath node -ArgumentList @('scripts/serve-static.mjs', 'packages/ts/cli/dist', '8765') -PassThru
+            Start-Sleep -Seconds 2
+          }
 
-          choco install sendmux --source "$source" -y --no-progress
-          sendmux --help
-          choco uninstall sendmux -y --no-progress
-          choco uninstall sendmux.portable -y --no-progress
+          try {
+            choco install sendmux.portable --source "$source" -y --no-progress
+            sendmux --help
+            choco uninstall sendmux.portable -y --no-progress
+
+            choco install sendmux --source "$source" -y --no-progress
+            sendmux --help
+            choco uninstall sendmux -y --no-progress
+            choco uninstall sendmux.portable -y --no-progress
+          } finally {
+            if ($server) {
+              Stop-Process -Id $server.Id -Force -ErrorAction SilentlyContinue
+            }
+          }
 
       - name: Upload workflow artefacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/packages/python/core/pyproject.toml
+++ b/packages/python/core/pyproject.toml
@@ -8,6 +8,15 @@ version = "1.1.2"
 description = "Shared runtime helpers for the Sendmux Python SDK packages."
 readme = "README.md"
 requires-python = ">=3.10"
+license = "MIT"
+classifiers = [
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+]
 dependencies = [
   "urllib3>=2.3.0,<3",
 ]

--- a/packages/python/mailbox/pyproject.toml
+++ b/packages/python/mailbox/pyproject.toml
@@ -8,6 +8,15 @@ version = "1.0.3"
 description = "Generated Python client for the Sendmux Mailbox API."
 readme = "README.md"
 requires-python = ">=3.10"
+license = "MIT"
+classifiers = [
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+]
 dependencies = [
   "certifi",
   "pydantic>=2,<3",

--- a/packages/python/management/pyproject.toml
+++ b/packages/python/management/pyproject.toml
@@ -8,6 +8,15 @@ version = "1.0.3"
 description = "Generated Python client for the Sendmux Management API."
 readme = "README.md"
 requires-python = ">=3.10"
+license = "MIT"
+classifiers = [
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+]
 dependencies = [
   "certifi",
   "pydantic>=2,<3",

--- a/packages/python/mcp/pyproject.toml
+++ b/packages/python/mcp/pyproject.toml
@@ -8,6 +8,15 @@ version = "1.1.3"
 description = "Curated MCP servers for the Sendmux API surfaces."
 readme = "README.md"
 requires-python = ">=3.10"
+license = "MIT"
+classifiers = [
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+]
 dependencies = [
   "fastmcp==3.3.1",
   "httpx>=0.28.1,<1",

--- a/packages/python/sdk/pyproject.toml
+++ b/packages/python/sdk/pyproject.toml
@@ -8,6 +8,15 @@ version = "1.0.3"
 description = "Umbrella package for the Sendmux Python SDK."
 readme = "README.md"
 requires-python = ">=3.10"
+license = "MIT"
+classifiers = [
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+]
 dependencies = [
   "sendmux-core>=1.0.0,<2.0.0",
   "sendmux-mailbox>=1.0.0,<2.0.0",

--- a/packages/python/sending/pyproject.toml
+++ b/packages/python/sending/pyproject.toml
@@ -8,6 +8,15 @@ version = "1.0.3"
 description = "Generated Python client for the Sendmux Sending API."
 readme = "README.md"
 requires-python = ">=3.10"
+license = "MIT"
+classifiers = [
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+]
 dependencies = [
   "certifi",
   "pydantic>=2,<3",

--- a/scripts/check-python.mjs
+++ b/scripts/check-python.mjs
@@ -9,6 +9,7 @@ const python = join(venv, "bin", "python");
 checkGeneratedMailboxBodyParamOrder();
 checkGeneratedMailboxTargeting();
 checkGeneratedPackageVersions();
+checkPythonPackageMetadata();
 
 if (!existsSync(python)) {
   mkdirSync(join(root, ".tmp"), { recursive: true });
@@ -156,6 +157,30 @@ function checkGeneratedPackageVersions() {
       ],
       forbiddenPattern: /SDK Package Version: (?!\{sdk_package_version\})[^"]+/,
     });
+  }
+}
+
+function checkPythonPackageMetadata() {
+  const packages = ["core", "sending", "mailbox", "management", "sdk", "mcp"];
+  const requiredSnippets = [
+    'requires-python = ">=3.10"',
+    'license = "MIT"',
+    '"License :: OSI Approved :: MIT License"',
+    '"Programming Language :: Python :: 3"',
+    '"Programming Language :: Python :: 3.10"',
+    '"Programming Language :: Python :: 3.11"',
+    '"Programming Language :: Python :: 3.12"',
+    '"Programming Language :: Python :: 3.13"',
+  ];
+
+  for (const packageName of packages) {
+    const pyprojectPath = join(root, "packages", "python", packageName, "pyproject.toml");
+    const pyproject = readFileSync(pyprojectPath, "utf8");
+    for (const snippet of requiredSnippets) {
+      if (!pyproject.includes(snippet)) {
+        throw new Error(`${pyprojectPath} is missing package metadata: ${snippet}`);
+      }
+    }
   }
 }
 

--- a/scripts/serve-static.mjs
+++ b/scripts/serve-static.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+import { createReadStream, statSync } from "node:fs";
+import { createServer } from "node:http";
+import { extname, isAbsolute, relative, resolve } from "node:path";
+
+const rootDir = resolve(process.argv[2] ?? ".");
+const port = Number(process.argv[3] ?? "8765");
+
+if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+  throw new Error(`Invalid port: ${process.argv[3]}`);
+}
+
+const server = createServer((request, response) => {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    response.writeHead(405, { Allow: "GET, HEAD" });
+    response.end();
+    return;
+  }
+
+  const url = new URL(request.url ?? "/", "http://127.0.0.1");
+  const filePath = resolve(rootDir, decodeURIComponent(url.pathname).replace(/^\/+/, ""));
+  const relativePath = relative(rootDir, filePath);
+
+  if (relativePath.startsWith("..") || isAbsolute(relativePath)) {
+    response.writeHead(403);
+    response.end();
+    return;
+  }
+
+  let stats;
+  try {
+    stats = statSync(filePath);
+  } catch {
+    response.writeHead(404);
+    response.end();
+    return;
+  }
+
+  if (!stats.isFile()) {
+    response.writeHead(404);
+    response.end();
+    return;
+  }
+
+  response.writeHead(200, {
+    "Content-Length": String(stats.size),
+    "Content-Type": contentType(filePath),
+  });
+
+  if (request.method === "HEAD") {
+    response.end();
+    return;
+  }
+
+  createReadStream(filePath).pipe(response);
+});
+
+server.listen(port, "127.0.0.1", () => {
+  console.log(`Serving ${rootDir} at http://127.0.0.1:${port}/`);
+});
+
+process.on("SIGTERM", () => server.close(() => process.exit(0)));
+process.on("SIGINT", () => server.close(() => process.exit(0)));
+
+function contentType(filePath) {
+  switch (extname(filePath).toLowerCase()) {
+    case ".zip":
+      return "application/zip";
+    case ".sha256":
+    case ".txt":
+      return "text/plain; charset=utf-8";
+    default:
+      return "application/octet-stream";
+  }
+}

--- a/scripts/test-chocolatey-workflow-order.mjs
+++ b/scripts/test-chocolatey-workflow-order.mjs
@@ -6,6 +6,7 @@ import { readFileSync } from "node:fs";
 const workflow = readFileSync(".github/workflows/chocolatey.yml", "utf8");
 
 const zipUpload = stepBlock("Attach CLI ZIP assets to release");
+const generatePackages = stepBlock("Generate Chocolatey packages");
 const testPackages = stepBlock("Test Chocolatey packages");
 const packageUpload = stepBlock("Attach Chocolatey package artefacts to release");
 
@@ -27,6 +28,26 @@ assert.doesNotMatch(
   packageUpload.text,
   /sendmux-v\*-win32-x64\.zip/,
   "Package upload must not duplicate the pre-test CLI ZIP upload.",
+);
+assert.match(
+  generatePackages.text,
+  /github\.event_name.*pull_request/s,
+  "PR Chocolatey package generation must override the download URL.",
+);
+assert.match(
+  generatePackages.text,
+  /SENDMUX_CHOCOLATEY_DOWNLOAD_URL/,
+  "PR Chocolatey package generation must write a local download URL.",
+);
+assert.match(
+  testPackages.text,
+  /scripts\/serve-static\.mjs/,
+  "PR Chocolatey package tests must serve the just-built ZIP locally.",
+);
+assert.match(
+  testPackages.text,
+  /Stop-Process/,
+  "PR Chocolatey package tests must stop the local ZIP server.",
 );
 
 console.log("Chocolatey workflow order tests passed.");


### PR DESCRIPTION
## Summary
- add MIT licence and Python classifiers to every Python package, including sendmux-mcp
- make check-python enforce package metadata going forward
- make Chocolatey PR installs test against the just-built local Windows ZIP instead of the existing release asset
- update CodeQL default setup separately to remove Rust from default CodeQL language analysis; the repo still has explicit Rust CI

## Verification
- pnpm build
- pnpm build:python:dists
- node --check scripts/serve-static.mjs
- pnpm test:windows-command-shims
- pnpm test:chocolatey-asset-tools
- pnpm test:chocolatey-workflow-order
- pnpm test:cli-tarball-tools
- built wheel metadata includes License-Expression: MIT, Python classifiers, and Requires-Python >=3.10

## Notes
- Existing PyPI files cannot be edited in place; the badges update on the next published Python package version.