### PR TITLE
fix(ruby-release): require current component versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,10 +29,10 @@ PATH
   remote: packages/ruby/sdk
   specs:
     sendmux-sdk (1.0.0)
-      sendmux-core (~> 1.0)
-      sendmux-mailbox (~> 1.0)
-      sendmux-management (~> 1.0)
-      sendmux-sending (~> 1.0)
+      sendmux-core (>= 1.0.0, < 2.0)
+      sendmux-mailbox (>= 1.0.0, < 2.0)
+      sendmux-management (>= 1.0.0, < 2.0)
+      sendmux-sending (>= 1.0.0, < 2.0)
 
 PATH
   remote: packages/ruby/sending

--- a/packages/ruby/sdk/sendmux-sdk.gemspec
+++ b/packages/ruby/sdk/sendmux-sdk.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   }
   spec.files = Dir.chdir(__dir__) { Dir['lib/**/*.rb', 'README.md', 'CHANGELOG.md', 'LICENSE'] }
   spec.require_paths = ['lib']
-  spec.add_dependency 'sendmux-core', '~> 1.0'
-  spec.add_dependency 'sendmux-mailbox', '~> 1.0'
-  spec.add_dependency 'sendmux-management', '~> 1.0'
-  spec.add_dependency 'sendmux-sending', '~> 1.0'
+  spec.add_dependency 'sendmux-core', '>= 1.0.0', '< 2.0'
+  spec.add_dependency 'sendmux-mailbox', '>= 1.0.0', '< 2.0'
+  spec.add_dependency 'sendmux-management', '>= 1.0.0', '< 2.0'
+  spec.add_dependency 'sendmux-sending', '>= 1.0.0', '< 2.0'
 end

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -100,30 +100,35 @@
       "component": "ruby-core",
       "package-name": "sendmux-core",
       "release-type": "ruby",
+      "version-file": "lib/sendmux/core/version.rb",
       "initial-version": "1.0.0"
     },
     "packages/ruby/sending": {
       "component": "ruby-sending",
       "package-name": "sendmux-sending",
       "release-type": "ruby",
+      "version-file": "lib/sendmux/sending/version.rb",
       "initial-version": "1.0.0"
     },
     "packages/ruby/mailbox": {
       "component": "ruby-mailbox",
       "package-name": "sendmux-mailbox",
       "release-type": "ruby",
+      "version-file": "lib/sendmux/mailbox/version.rb",
       "initial-version": "1.0.0"
     },
     "packages/ruby/management": {
       "component": "ruby-management",
       "package-name": "sendmux-management",
       "release-type": "ruby",
+      "version-file": "lib/sendmux/management/version.rb",
       "initial-version": "1.0.0"
     },
     "packages/ruby/sdk": {
       "component": "ruby-sdk",
       "package-name": "sendmux-sdk",
       "release-type": "ruby",
+      "version-file": "lib/sendmux/sdk/version.rb",
       "initial-version": "1.0.0"
     }
   }

--- a/scripts/check-ruby.mjs
+++ b/scripts/check-ruby.mjs
@@ -18,6 +18,7 @@ for (const name of packages) {
 }
 
 runShell(`find packages/ruby -name '*.rb' -print0 | xargs -0 -n 1 ${ruby.join(" ")} -c`);
+checkRubyDependencyFloors();
 run(bundle, ["exec", "rubocop", "packages/ruby"]);
 run(bundle, ["exec", "ruby", "-Ipackages/ruby/tests", "packages/ruby/tests/test_core.rb"]);
 
@@ -36,6 +37,64 @@ function readVersion(name) {
     throw new Error(`Could not read Ruby version for ${name}`);
   }
   return match[1];
+}
+
+function checkRubyDependencyFloors() {
+  const manifest = JSON.parse(readFileSync(`${root}/.release-please-manifest.json`, "utf8"));
+  const dependencyChecks = [
+    {
+      gemspecPath: "packages/ruby/sending/sendmux-sending.gemspec",
+      dependencies: [["sendmux-core", manifest["packages/ruby/core"]]],
+    },
+    {
+      gemspecPath: "packages/ruby/sdk/sendmux-sdk.gemspec",
+      dependencies: [
+        ["sendmux-core", manifest["packages/ruby/core"]],
+        ["sendmux-mailbox", manifest["packages/ruby/mailbox"]],
+        ["sendmux-management", manifest["packages/ruby/management"]],
+        ["sendmux-sending", manifest["packages/ruby/sending"]],
+      ],
+    },
+  ];
+
+  for (const { gemspecPath, dependencies } of dependencyChecks) {
+    const source = readFileSync(`${root}/${gemspecPath}`, "utf8");
+    for (const [dependency, minimumVersion] of dependencies) {
+      if (typeof minimumVersion !== "string") {
+        throw new Error(`Could not read release manifest version for ${dependency}`);
+      }
+
+      const dependencyPattern = new RegExp(
+        `spec\\.add_dependency '${dependency}', '>= ([^']+)', '< 2\\.0'`,
+      );
+      const actualVersion = source.match(dependencyPattern)?.[1];
+      if (!actualVersion) {
+        throw new Error(`${gemspecPath} must require ${dependency} with an explicit >= floor and < 2.0 upper bound`);
+      }
+      if (compareSemver(actualVersion, minimumVersion) < 0) {
+        throw new Error(`${gemspecPath} must require ${dependency} >= ${minimumVersion}; found >= ${actualVersion}`);
+      }
+    }
+  }
+}
+
+function compareSemver(left, right) {
+  const leftParts = parseSemver(left);
+  const rightParts = parseSemver(right);
+  for (let index = 0; index < 3; index += 1) {
+    if (leftParts[index] !== rightParts[index]) {
+      return leftParts[index] - rightParts[index];
+    }
+  }
+  return 0;
+}
+
+function parseSemver(version) {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) {
+    throw new Error(`Unsupported Ruby dependency version: ${version}`);
+  }
+  return match.slice(1).map(Number);
 }
 
 function run(commandParts, args, options = {}) {


### PR DESCRIPTION
## Summary
- bump Ruby core/sending/sdk package version files so release jobs publish the intended 1.1.0 artifacts
- raise Ruby dependency floors so sending/sdk install the component versions their releases require
- configure release-please to update Ruby version files and add a check for dependency-floor drift

## Verification
- pnpm install --frozen-lockfile
- pnpm build:ruby
- node scripts/check-ruby.mjs
- gem specification .tmp/ruby-dist/sendmux-sending-1.1.0.gem dependencies
- gem specification .tmp/ruby-dist/sendmux-sdk-1.1.0.gem dependencies
- git diff --check
