### PR TITLE
fix(ruby-release): scope dependency floor checks

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -551,6 +551,8 @@ jobs:
 
       - name: Build Ruby gems
         run: pnpm build:ruby
+        env:
+          RUBY_PATHS_RELEASED: ${{ needs.release-please.outputs.paths_released }}
 
       - name: Configure RubyGems trusted publishing credentials
         uses: rubygems/configure-rubygems-credentials@762a4b77c3300434bb57c7ce80b20e36231927aa # v2.0.0

--- a/scripts/check-ruby.mjs
+++ b/scripts/check-ruby.mjs
@@ -41,12 +41,15 @@ function readVersion(name) {
 
 function checkRubyDependencyFloors() {
   const manifest = JSON.parse(readFileSync(`${root}/.release-please-manifest.json`, "utf8"));
+  const changedPackages = readChangedRubyPackages();
   const dependencyChecks = [
     {
+      packageName: "sending",
       gemspecPath: "packages/ruby/sending/sendmux-sending.gemspec",
       dependencies: [["sendmux-core", manifest["packages/ruby/core"]]],
     },
     {
+      packageName: "sdk",
       gemspecPath: "packages/ruby/sdk/sendmux-sdk.gemspec",
       dependencies: [
         ["sendmux-core", manifest["packages/ruby/core"]],
@@ -57,8 +60,9 @@ function checkRubyDependencyFloors() {
     },
   ];
 
-  for (const { gemspecPath, dependencies } of dependencyChecks) {
+  for (const { packageName, gemspecPath, dependencies } of dependencyChecks) {
     const source = readFileSync(`${root}/${gemspecPath}`, "utf8");
+    const enforceManifestFloor = changedPackages.has(packageName);
     for (const [dependency, minimumVersion] of dependencies) {
       if (typeof minimumVersion !== "string") {
         throw new Error(`Could not read release manifest version for ${dependency}`);
@@ -71,11 +75,92 @@ function checkRubyDependencyFloors() {
       if (!actualVersion) {
         throw new Error(`${gemspecPath} must require ${dependency} with an explicit >= floor and < 2.0 upper bound`);
       }
-      if (compareSemver(actualVersion, minimumVersion) < 0) {
+      if (enforceManifestFloor && compareSemver(actualVersion, minimumVersion) < 0) {
         throw new Error(`${gemspecPath} must require ${dependency} >= ${minimumVersion}; found >= ${actualVersion}`);
       }
     }
   }
+}
+
+function readChangedRubyPackages() {
+  const override = process.env.RUBY_CHANGED_PACKAGES;
+  if (override) {
+    return new Set(
+      override
+        .split(",")
+        .map((value) => value.trim())
+        .filter(Boolean)
+        .map(validateRubyPackageName),
+    );
+  }
+
+  const releasedPackages = readRubyPackagesFromPaths(process.env.RUBY_PATHS_RELEASED);
+  if (releasedPackages.size > 0) {
+    return releasedPackages;
+  }
+
+  const changedFiles = readChangedFiles();
+  const changedPackages = new Set();
+  for (const filePath of changedFiles) {
+    const match = filePath.match(/^packages\/ruby\/([^/]+)\//);
+    if (match && packages.includes(match[1])) {
+      changedPackages.add(validateRubyPackageName(match[1]));
+    }
+  }
+  return changedPackages;
+}
+
+function readRubyPackagesFromPaths(value) {
+  if (!value) {
+    return new Set();
+  }
+
+  let paths;
+  try {
+    const parsed = JSON.parse(value);
+    paths = Array.isArray(parsed) ? parsed : [parsed];
+  } catch {
+    paths = value.split(/[\s,]+/);
+  }
+
+  const rubyPackages = new Set();
+  for (const filePath of paths) {
+    if (typeof filePath !== "string") {
+      continue;
+    }
+    const match = filePath.match(/^packages\/ruby\/([^/]+)$/);
+    if (match && packages.includes(match[1])) {
+      rubyPackages.add(validateRubyPackageName(match[1]));
+    }
+  }
+  return rubyPackages;
+}
+
+function readChangedFiles() {
+  const ranges = [];
+  if (process.env.GITHUB_BASE_REF) {
+    ranges.push(`origin/${process.env.GITHUB_BASE_REF}...HEAD`);
+  }
+  ranges.push("origin/main...HEAD");
+
+  for (const range of ranges) {
+    const result = spawnSync("git", ["diff", "--name-only", range], {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    if (result.status === 0) {
+      return result.stdout.split("\n").filter(Boolean);
+    }
+  }
+  return [];
+}
+
+function validateRubyPackageName(name) {
+  if (!packages.includes(name)) {
+    throw new Error(`Unknown Ruby package name: ${name}`);
+  }
+  return name;
 }
 
 function compareSemver(left, right) {


### PR DESCRIPTION
## Summary
- keep Ruby dependency range-shape validation global
- scope manifest-version floor comparisons to the Ruby package changed by the current branch or explicit `RUBY_CHANGED_PACKAGES` override
- unblock core-only release PRs while still catching stale floors on sending/sdk release verification

## Root cause
The previous guard compared every Ruby dependent package against the PR manifest unconditionally. A core-only release PR advances `packages/ruby/core` in the manifest before `ruby-sending` is released, so the check produced a false positive.

## Verification
- node scripts/check-ruby.mjs
- RUBY_CHANGED_PACKAGES=sending node scripts/check-ruby.mjs
- RUBY_CHANGED_PACKAGES=sdk node scripts/check-ruby.mjs
- node /Users/rj/Desktop/GIT-REPOS/sendmux-sdk-ruby-release-floors/scripts/check-ruby.mjs from PR #64 checkout
- RUBY_CHANGED_PACKAGES=sending node /Users/rj/Desktop/GIT-REPOS/sendmux-sdk-ruby-release-floors/scripts/check-ruby.mjs from PR #64 checkout, expected failure on stale core floor
- pnpm build:ruby
- git diff --check
