### PR TITLE
chore(snap): update CLI snap to 1.1.0

### DIFF
--- a/snap/README.md
+++ b/snap/README.md
@@ -98,7 +98,8 @@ On a Linux host with snapd, Snapcraft, and a configured build provider:
 ```sh
 cd /path/to/sendmux-sdk
 snapcraft pack
-sudo snap install ./sendmux_1.0.1_*.snap --dangerous
+VERSION=$(grep '^version:' snap/snapcraft.yaml | cut -d'"' -f2)
+sudo snap install ./sendmux_${VERSION}_*.snap --dangerous
 sendmux --help
 sendmux profiles:list --json
 sudo snap remove sendmux
@@ -151,7 +152,10 @@ add `removable-media` later only if there is a verified user need.
    - Or, after confirming Launchpad public/private upload policy:
      `snapcraft remote-build --build-for amd64,arm64`
 4. Upload first to edge:
-   - `snapcraft upload ./sendmux_1.0.1_*.snap --release=edge`
+   ```sh
+   VERSION=$(grep '^version:' snap/snapcraft.yaml | cut -d'"' -f2)
+   snapcraft upload ./sendmux_${VERSION}_*.snap --release=edge
+   ```
 5. Smoke-test from the store on a separate Linux host:
    - `sudo snap install sendmux --edge`
    - `sendmux --help`

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: sendmux
 title: Sendmux CLI
 base: core26
-version: "1.0.1"
+version: "1.1.0"
 summary: Official command-line interface for Sendmux email APIs
 description: |
   Manage Sendmux from Linux terminals and automation with the official Sendmux CLI.
@@ -40,9 +40,9 @@ apps:
 parts:
   sendmux:
     plugin: npm
-    source: https://registry.npmjs.org/@sendmux/cli/-/cli-1.0.1.tgz
+    source: https://registry.npmjs.org/@sendmux/cli/-/cli-1.1.0.tgz
     source-type: tar
-    source-checksum: sha512/b469f7761c5b13b638a15a7af9d0b575617493f037d1d909c5d584f7c73ac8c7162f39830ed0ecb79b4f4d535e7a62f2c3a8c14538f04cfaea084278a64a21ae
+    source-checksum: sha512/982d311542861b916c390c7f53ac7ed19ed0c8c000cd91163d9f38be3500dc400a3a82280290a6cdbb1100e43d12fc1bedc304dc77a02859e036b94e9697278e
     npm-include-node: true
     npm-node-version: "22.22.3"
 


### PR DESCRIPTION
## Summary
- update Snapcraft metadata to package @sendmux/cli 1.1.0
- update the npm tarball source and SHA-512 checksum
- make snap README install/upload examples derive the version from snapcraft.yaml

## Verification
- npm view @sendmux/cli@1.1.0 dist --json
- shasum -a 512 .tmp/snap/cli-1.1.0.tgz
- ruby YAML static check for snap/snapcraft.yaml
- git diff --check
- snapcraft pack attempted; blocked locally because Multipass could not find snapcraft:resolute for core26