### PR TITLE
fix(sdk): make python release guardrails component-aware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Check out SDK
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       - name: Check out OpenAPI snapshots
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -313,6 +313,8 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build Python distributions
+        env:
+          PYTHON_PATHS_RELEASED: ${{ needs.release-please.outputs.paths_released }}
         run: pnpm build:python:dists
 
       - name: Select unpublished Python distributions

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "packageManager": "pnpm@10.22.0",
   "scripts": {
-    "build": "pnpm drift:check && pnpm -r --if-present build && pnpm verify:layout && pnpm verify:ts-public-api && pnpm verify:tree-shaking && pnpm test:ts-helpers && pnpm test:windows-command-shims && pnpm test:chocolatey-asset-tools && pnpm test:chocolatey-workflow-order && pnpm test:cli-tarball-tools && pnpm check:cli && pnpm check:surface-coverage && pnpm check:live-e2e && pnpm build:go && pnpm build:python && pnpm build:php && pnpm build:ruby && pnpm build:mcp",
+    "build": "pnpm drift:check && pnpm -r --if-present build && pnpm verify:layout && pnpm verify:ts-public-api && pnpm verify:tree-shaking && pnpm test:ts-helpers && pnpm test:python-release-guardrails && pnpm test:windows-command-shims && pnpm test:chocolatey-asset-tools && pnpm test:chocolatey-workflow-order && pnpm test:cli-tarball-tools && pnpm check:cli && pnpm check:surface-coverage && pnpm check:live-e2e && pnpm build:go && pnpm build:python && pnpm build:php && pnpm build:ruby && pnpm build:mcp",
     "build:go": "pnpm generate:go && node scripts/check-go.mjs && cd go && go test ./... && go vet ./... && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.3.0 run",
     "build:mcp": "pnpm generate:mcp && node scripts/check-mcp.mjs",
     "build:php": "pnpm generate:php && node scripts/check-php.mjs && node scripts/check-php-splits.mjs",
@@ -37,6 +37,7 @@
     "test:chocolatey-workflow-order": "node scripts/test-chocolatey-workflow-order.mjs",
     "test:cli-tarball-tools": "node scripts/test-cli-tarball-tools.mjs",
     "test:ts-helpers": "node scripts/test-ts-helpers.mjs",
+    "test:python-release-guardrails": "node scripts/test-python-release-guardrails.mjs",
     "test:windows-command-shims": "node scripts/test-windows-command-shims.mjs",
     "verify:codegen": "node scripts/verify-normalized-openapi.mjs",
     "verify:layout": "node scripts/verify-layout.mjs",

--- a/scripts/check-python.mjs
+++ b/scripts/check-python.mjs
@@ -1,6 +1,10 @@
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
+import {
+  checkPythonMcpDependencyFloors,
+  checkPythonSdkDependencyFloors,
+} from "./python-release-guardrails.mjs";
 
 const root = process.cwd();
 const venv = join(root, ".tmp", "python-venv");
@@ -10,8 +14,8 @@ checkGeneratedMailboxBodyParamOrder();
 checkGeneratedMailboxTargeting();
 checkGeneratedPackageVersions();
 checkPythonPackageMetadata();
-checkPythonSdkDependencyFloors();
-checkPythonMcpDependencyFloors();
+checkPythonSdkDependencyFloors({ root });
+checkPythonMcpDependencyFloors({ root });
 
 if (!existsSync(python)) {
   mkdirSync(join(root, ".tmp"), { recursive: true });
@@ -183,45 +187,6 @@ function checkPythonPackageMetadata() {
         throw new Error(`${pyprojectPath} is missing package metadata: ${snippet}`);
       }
     }
-  }
-}
-
-function checkPythonSdkDependencyFloors() {
-  const manifest = JSON.parse(readFileSync(join(root, ".release-please-manifest.json"), "utf8"));
-  const pyprojectPath = join(root, "packages", "python", "sdk", "pyproject.toml");
-  const pyproject = readFileSync(pyprojectPath, "utf8");
-  const dependencies = [
-    ["sendmux-core", manifest["packages/python/core"]],
-    ["sendmux-mailbox", manifest["packages/python/mailbox"]],
-    ["sendmux-management", manifest["packages/python/management"]],
-    ["sendmux-sending", manifest["packages/python/sending"]],
-  ];
-
-  for (const [packageName, version] of dependencies) {
-    if (typeof version !== "string") {
-      throw new Error(`Could not read release manifest version for ${packageName}`);
-    }
-
-    const expected = `"${packageName}>=${version},<2.0.0"`;
-    if (!pyproject.includes(expected)) {
-      throw new Error(`${pyprojectPath} must require ${expected}`);
-    }
-  }
-}
-
-function checkPythonMcpDependencyFloors() {
-  const manifest = JSON.parse(readFileSync(join(root, ".release-please-manifest.json"), "utf8"));
-  const pyprojectPath = join(root, "packages", "python", "mcp", "pyproject.toml");
-  const pyproject = readFileSync(pyprojectPath, "utf8");
-  const coreVersion = manifest["packages/python/core"];
-
-  if (typeof coreVersion !== "string") {
-    throw new Error("Could not read release manifest version for sendmux-core");
-  }
-
-  const expected = `"sendmux-core>=${coreVersion},<2.0.0"`;
-  if (!pyproject.includes(expected)) {
-    throw new Error(`${pyprojectPath} must require ${expected}`);
   }
 }
 

--- a/scripts/python-release-guardrails.mjs
+++ b/scripts/python-release-guardrails.mjs
@@ -1,0 +1,177 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+export const pythonPackages = ["core", "sending", "mailbox", "management", "sdk", "mcp"];
+
+export function checkPythonSdkDependencyFloors({ root, changedPackages = readChangedPythonPackages({ root }) }) {
+  const manifest = readManifest(root);
+  const pyprojectPath = join(root, "packages", "python", "sdk", "pyproject.toml");
+  const pyproject = readFileSync(pyprojectPath, "utf8");
+  const dependencies = [
+    ["sendmux-core", manifest["packages/python/core"]],
+    ["sendmux-mailbox", manifest["packages/python/mailbox"]],
+    ["sendmux-management", manifest["packages/python/management"]],
+    ["sendmux-sending", manifest["packages/python/sending"]],
+  ];
+
+  checkDependencyFloors({
+    source: pyproject,
+    sourcePath: pyprojectPath,
+    dependencies,
+    enforceManifestFloor: changedPackages.has("sdk"),
+  });
+}
+
+export function checkPythonMcpDependencyFloors({ root, changedPackages = readChangedPythonPackages({ root }) }) {
+  const manifest = readManifest(root);
+  const pyprojectPath = join(root, "packages", "python", "mcp", "pyproject.toml");
+  const pyproject = readFileSync(pyprojectPath, "utf8");
+
+  checkDependencyFloors({
+    source: pyproject,
+    sourcePath: pyprojectPath,
+    dependencies: [["sendmux-core", manifest["packages/python/core"]]],
+    enforceManifestFloor: changedPackages.has("mcp"),
+  });
+}
+
+export function readChangedPythonPackages({ root, env = process.env } = {}) {
+  const override = env.PYTHON_CHANGED_PACKAGES;
+  if (override) {
+    return new Set(
+      override
+        .split(",")
+        .map((value) => value.trim())
+        .filter(Boolean)
+        .map(validatePythonPackageName),
+    );
+  }
+
+  const releasedPackages = readPythonPackagesFromPaths(env.PYTHON_PATHS_RELEASED);
+  if (releasedPackages.size > 0) {
+    return releasedPackages;
+  }
+
+  const changedFiles = readChangedFiles(root, env);
+  const changedPackages = new Set();
+  for (const filePath of changedFiles) {
+    const match = filePath.match(/^packages\/python\/([^/]+)\//);
+    if (match && pythonPackages.includes(match[1])) {
+      changedPackages.add(validatePythonPackageName(match[1]));
+    }
+    const directMatch = filePath.match(/^packages\/python\/([^/]+)$/);
+    if (directMatch && pythonPackages.includes(directMatch[1])) {
+      changedPackages.add(validatePythonPackageName(directMatch[1]));
+    }
+  }
+  return changedPackages;
+}
+
+function checkDependencyFloors({ source, sourcePath, dependencies, enforceManifestFloor }) {
+  for (const [packageName, minimumVersion] of dependencies) {
+    if (typeof minimumVersion !== "string") {
+      throw new Error(`Could not read release manifest version for ${packageName}`);
+    }
+
+    const dependencyPattern = new RegExp(`"${escapeRegExp(packageName)}>=([^,"]+),<2\\.0\\.0"`);
+    const actualVersion = source.match(dependencyPattern)?.[1];
+    if (!actualVersion) {
+      throw new Error(`${sourcePath} must require ${packageName} with an explicit >= floor and <2.0.0 upper bound`);
+    }
+    if (enforceManifestFloor && compareSemver(actualVersion, minimumVersion) !== 0) {
+      throw new Error(
+        `${sourcePath} must require ${packageName} >= ${minimumVersion},<2.0.0; found >= ${actualVersion},<2.0.0`,
+      );
+    }
+  }
+}
+
+function readManifest(root) {
+  return JSON.parse(readFileSync(join(root, ".release-please-manifest.json"), "utf8"));
+}
+
+function readPythonPackagesFromPaths(value) {
+  if (!value) {
+    return new Set();
+  }
+
+  let paths;
+  try {
+    const parsed = JSON.parse(value);
+    paths = Array.isArray(parsed) ? parsed : [parsed];
+  } catch {
+    paths = value.split(/[\s,]+/);
+  }
+
+  const changedPackages = new Set();
+  for (const filePath of paths) {
+    if (typeof filePath !== "string") {
+      continue;
+    }
+    const match = filePath.match(/^packages\/python\/([^/]+)\//);
+    if (match && pythonPackages.includes(match[1])) {
+      changedPackages.add(validatePythonPackageName(match[1]));
+    }
+    const directMatch = filePath.match(/^packages\/python\/([^/]+)$/);
+    if (directMatch && pythonPackages.includes(directMatch[1])) {
+      changedPackages.add(validatePythonPackageName(directMatch[1]));
+    }
+  }
+  return changedPackages;
+}
+
+function readChangedFiles(root, env = process.env) {
+  const ranges = [];
+  if (env.GITHUB_BASE_REF) {
+    ranges.push(`origin/${env.GITHUB_BASE_REF}...HEAD`);
+  }
+  ranges.push("origin/main...HEAD");
+
+  for (const range of ranges) {
+    const result = spawnSync("git", ["diff", "--name-only", range], {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    if (result.status === 0) {
+      return result.stdout.split("\n").filter(Boolean);
+    }
+  }
+  if (env.GITHUB_BASE_REF) {
+    throw new Error(
+      "Could not determine changed files for Python release guardrails. Configure actions/checkout with fetch-depth: 0 or set PYTHON_CHANGED_PACKAGES/PYTHON_PATHS_RELEASED.",
+    );
+  }
+  return [];
+}
+
+function validatePythonPackageName(name) {
+  if (!pythonPackages.includes(name)) {
+    throw new Error(`Unknown Python package name: ${name}`);
+  }
+  return name;
+}
+
+function compareSemver(left, right) {
+  const leftParts = parseSemver(left);
+  const rightParts = parseSemver(right);
+  for (let index = 0; index < 3; index += 1) {
+    if (leftParts[index] !== rightParts[index]) {
+      return leftParts[index] - rightParts[index];
+    }
+  }
+  return 0;
+}
+
+function parseSemver(version) {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) {
+    throw new Error(`Unsupported Python dependency version: ${version}`);
+  }
+  return match.slice(1).map(Number);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/scripts/test-python-release-guardrails.mjs
+++ b/scripts/test-python-release-guardrails.mjs
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  checkPythonMcpDependencyFloors,
+  checkPythonSdkDependencyFloors,
+  readChangedPythonPackages,
+} from "./python-release-guardrails.mjs";
+
+const root = mkdtempSync(join(tmpdir(), "sendmux-python-release-"));
+
+try {
+  writeFixture({
+    manifest: {
+      "packages/python/core": "1.2.0",
+      "packages/python/mailbox": "1.0.4",
+      "packages/python/management": "1.0.4",
+      "packages/python/sending": "1.2.0",
+    },
+    sdkDependencies: [
+      '"sendmux-core>=1.2.0,<2.0.0"',
+      '"sendmux-mailbox>=1.0.4,<2.0.0"',
+      '"sendmux-management>=1.0.4,<2.0.0"',
+      '"sendmux-sending>=1.1.0,<2.0.0"',
+    ],
+    mcpDependencies: ['"sendmux-core>=1.1.0,<2.0.0"'],
+  });
+
+  assert.doesNotThrow(() =>
+    checkPythonSdkDependencyFloors({ root, changedPackages: new Set(["sending"]) }),
+  );
+  assert.throws(
+    () => checkPythonSdkDependencyFloors({ root, changedPackages: new Set(["sdk"]) }),
+    /sendmux-sending >= 1\.2\.0,<2\.0\.0; found >= 1\.1\.0,<2\.0\.0/,
+  );
+  assert.doesNotThrow(() => checkPythonMcpDependencyFloors({ root, changedPackages: new Set(["core"]) }));
+  assert.throws(
+    () => checkPythonMcpDependencyFloors({ root, changedPackages: new Set(["mcp"]) }),
+    /sendmux-core >= 1\.2\.0,<2\.0\.0; found >= 1\.1\.0,<2\.0\.0/,
+  );
+
+  writeFixture({
+    manifest: {
+      "packages/python/core": "1.2.0",
+      "packages/python/mailbox": "1.1.0",
+      "packages/python/management": "1.0.4",
+      "packages/python/sending": "1.2.0",
+    },
+    sdkDependencies: [
+      '"sendmux-core>=1.2.0,<2.0.0"',
+      '"sendmux-mailbox>=1.1.0,<2.0.0"',
+      '"sendmux-management>=1.0.4,<2.0.0"',
+      '"sendmux-sending>=1.3.0,<2.0.0"',
+    ],
+    mcpDependencies: ['"sendmux-core>=1.2.0,<2.0.0"'],
+  });
+
+  assert.throws(
+    () => checkPythonSdkDependencyFloors({ root, changedPackages: new Set(["sdk"]) }),
+    /sendmux-sending >= 1\.2\.0,<2\.0\.0; found >= 1\.3\.0,<2\.0\.0/,
+  );
+
+  writeFixture({
+    manifest: {
+      "packages/python/core": "1.2.0",
+      "packages/python/mailbox": "1.1.0",
+      "packages/python/management": "1.0.4",
+      "packages/python/sending": "1.2.0",
+    },
+    sdkDependencies: [
+      '"sendmux-core>=1.2.0,<2.0.0"',
+      '"sendmux-mailbox>=1.1.0,<2.0.0"',
+      '"sendmux-management>=1.0.4,<2.0.0"',
+      '"sendmux-sending>=1.2.0,<2.0.0"',
+    ],
+    mcpDependencies: ['"sendmux-core>=1.2.0,<2.0.0"'],
+  });
+
+  assert.doesNotThrow(() => checkPythonSdkDependencyFloors({ root, changedPackages: new Set(["sdk"]) }));
+  assert.doesNotThrow(() => checkPythonMcpDependencyFloors({ root, changedPackages: new Set(["mcp"]) }));
+
+  writeFixture({
+    manifest: {
+      "packages/python/core": "1.2.0",
+      "packages/python/mailbox": "1.1.0",
+      "packages/python/management": "1.0.4",
+      "packages/python/sending": "1.2.0",
+    },
+    sdkDependencies: [
+      '"sendmux-core>=1.2.0,<2.0.0"',
+      '"sendmux-mailbox>=1.1.0"',
+      '"sendmux-management>=1.0.4,<2.0.0"',
+      '"sendmux-sending>=1.2.0,<2.0.0"',
+    ],
+    mcpDependencies: ['"sendmux-core>=1.2.0,<2.0.0"'],
+  });
+
+  assert.throws(
+    () => checkPythonSdkDependencyFloors({ root, changedPackages: new Set(["sending"]) }),
+    /sendmux-mailbox with an explicit >= floor and <2\.0\.0 upper bound/,
+  );
+
+  assert.deepEqual(
+    [...readChangedPythonPackages({ env: { PYTHON_CHANGED_PACKAGES: "sending, sdk" } })].sort(),
+    ["sdk", "sending"],
+  );
+  assert.deepEqual(
+    [
+      ...readChangedPythonPackages({
+        env: { PYTHON_PATHS_RELEASED: '["packages/python/mailbox","packages/ts/cli"]' },
+      }),
+    ],
+    ["mailbox"],
+  );
+  assert.throws(
+    () => readChangedPythonPackages({ root, env: { GITHUB_BASE_REF: "main" } }),
+    /Could not determine changed files for Python release guardrails/,
+  );
+
+  console.log("Python release guardrail tests passed.");
+} finally {
+  rmSync(root, { force: true, recursive: true });
+}
+
+function writeFixture({ manifest, sdkDependencies, mcpDependencies }) {
+  mkdirSync(join(root, "packages", "python", "sdk"), { recursive: true });
+  mkdirSync(join(root, "packages", "python", "mcp"), { recursive: true });
+  writeFileSync(join(root, ".release-please-manifest.json"), `${JSON.stringify(manifest)}\n`);
+  writeFileSync(
+    join(root, "packages", "python", "sdk", "pyproject.toml"),
+    `dependencies = [\n  ${sdkDependencies.join(",\n  ")}\n]\n`,
+  );
+  writeFileSync(
+    join(root, "packages", "python", "mcp", "pyproject.toml"),
+    `dependencies = [\n  ${mcpDependencies.join(",\n  ")}\n]\n`,
+  );
+}


### PR DESCRIPTION
## Summary
- make Python dependency floor checks release-path-aware so component release PRs can publish without forcing umbrella SDK floors early
- pass Release Please paths into the PyPI publish build via PYTHON_PATHS_RELEASED
- add focused guardrail coverage for component, SDK, MCP, and released-path parsing cases

## Verification
- pnpm test:python-release-guardrails
- pnpm canary:openapi --docs-dir /Users/rj/Desktop/GIT-REPOS/sendmux-docs
- PYTHON_PATHS_RELEASED='["packages/python/sending"]' pnpm build:python:dists
- pnpm prepare:publish:pypi
- pnpm build