### PR TITLE
chore(snap): update CLI snap to 1.3.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: sendmux
 title: Sendmux CLI
 base: core26
-version: "1.2.0"
+version: "1.3.0"
 summary: Official command-line interface for Sendmux email APIs
 description: |
   Manage Sendmux from Linux terminals and automation with the official Sendmux CLI.
@@ -40,9 +40,9 @@ apps:
 parts:
   sendmux:
     plugin: npm
-    source: https://registry.npmjs.org/@sendmux/cli/-/cli-1.2.0.tgz
+    source: https://registry.npmjs.org/@sendmux/cli/-/cli-1.3.0.tgz
     source-type: tar
-    source-checksum: sha512/1dd6b0f4f93c88bd9f691d8cdff403939945fc108f5e430d63e066f640a7a0b0b99048365950a04f8382982a9709c54574d0a4e3b1d30719ce587d943d92114f
+    source-checksum: sha512/53b059e633f150f42634f46b8cfc50deb2eabe467fe5ae821d382afe05c7f5d9f587f5ef0a63c75e3af64fdc376ef585c068e5d958fe08c3906f9ddcd70636d1
     npm-include-node: true
     npm-node-version: "22.22.3"
 


### PR DESCRIPTION
## Summary
- update the Snapcraft package metadata to @sendmux/cli 1.3.0
- point the snap source at the published npm tarball
- update source-checksum to the npm tarball sha512 digest

## Verification
- npm view @sendmux/cli@1.3.0 dist.tarball dist.integrity --json
- computed tarball sha512 matches snap/snapcraft.yaml
- snapcraft pack parsed the project, then failed before build because local macOS Multipass could not find snapcraft:resolute; Snapcraft GitHub Builds remains the canonical build gate
