### PR TITLE
fix(packages): registry metadata + full READMEs for the framework wrappers

### DIFF
--- a/packages/python/langchain/README.md
+++ b/packages/python/langchain/README.md
@@ -1,6 +1,13 @@
 # langchain-sendmux
 
-[LangChain](https://docs.langchain.com) toolkit for [Sendmux](https://sendmux.ai), the email API for AI agents. Give a LangChain agent tools to send email and read its own inbox.
+[LangChain](https://docs.langchain.com) toolkit for [Sendmux](https://sendmux.ai), the email API for AI agents.
+
+Gives an agent its own mailbox: it can send email, read what arrives, and reply from its own address.
+
+## Requirements
+
+- Python 3.10 or newer
+- `langchain-core` v1
 
 ## Installation
 
@@ -8,15 +15,30 @@
 pip install langchain-sendmux
 ```
 
-## Usage
+## Getting an API key
+
+The toolkit needs a key that can both send and receive. Two ways to get one:
+
+- **Dashboard** — create a mailbox and a mailbox-scoped key (`smx_mbx_*`). See [API keys](https://sendmux.ai/docs/guides/api-keys).
+- **Agent self-registration** — the agent claims its own `@myagent.mx` mailbox and gets an `smx_agent_*` token, with no human signup first. See [email for AI agents](https://sendmux.ai/solutions/for-ai-agents/).
+
+Note on agent tokens: a freshly self-registered `smx_agent_*` token can read and receive, but **cannot send** until a human owner has been invited and has approved it. Until then `send_email` and `reply` will fail. A dashboard `smx_mbx_*` key with send permission works immediately.
+
+Read the key from the environment. Never hard-code it.
+
+## Quick start
 
 ```python
 import os
 
 from langchain.agents import create_agent
+
 from langchain_sendmux import SendmuxToolkit
 
-smx = SendmuxToolkit(api_key=os.environ["SENDMUX_API_KEY"])
+smx = SendmuxToolkit(
+    api_key=os.environ["SENDMUX_API_KEY"],
+    default_from="agent@yourdomain.dev",
+)
 
 agent = create_agent(
     model="gpt-4o",
@@ -24,21 +46,81 @@ agent = create_agent(
     system_prompt="You triage the support inbox.",
 )
 
-agent.invoke({"messages": [{"role": "user", "content": "Reply to Sarah."}]})
+agent.invoke(
+    {"messages": [{"role": "user", "content": "Reply to anyone asking about pricing."}]}
+)
 ```
 
 ## Tools
 
-`SendmuxToolkit(api_key=...).get_tools()` returns three tools:
+`SendmuxToolkit(...).get_tools()` returns three tools.
 
-- `send_email` - send an email to any recipient through Sendmux.
-- `list_messages` - list recent messages in the agent's mailbox.
-- `reply` - send a message from the agent's own mailbox.
+### `send_email`
+
+Sends through your configured sending providers, to any recipient.
+
+| Parameter | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `to` | str | yes | Recipient email address |
+| `subject` | str | yes | Subject line |
+| `text` | str | yes | Plain-text body |
+| `html` | str | no | HTML body. Generated from `text` if omitted |
+| `var_from` | str | no | Sender address. Falls back to `default_from` |
+| `idempotency_key` | str | no | Makes a retried send idempotent for 24 hours |
+
+`var_from` is spelt that way because `from` is a reserved word in Python.
+
+### `list_messages`
+
+Lists messages in the agent's own mailbox, newest first.
+
+| Parameter | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `limit` | int | no | How many to return, 1 to 100. Defaults to 25 |
+
+### `reply`
+
+Sends from the agent's own mailbox address, rather than through a sending provider. Use this to answer someone who wrote in.
+
+| Parameter | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `to` | str | yes | Recipient email address |
+| `subject` | str | yes | Subject line |
+| `text` | str | yes | Plain-text body |
+| `html` | str | no | HTML body. Generated from `text` if omitted |
+| `idempotency_key` | str | no | Makes a retried send idempotent for 24 hours |
 
 ## Configuration
 
-- `api_key` (required) - a send + receive capable mailbox API key (`smx_mbx_*`) or a scoped agent token.
-- `default_from` (optional) - default From address for `send_email` when a call omits `var_from`.
+```python
+SendmuxToolkit(api_key=..., default_from=...)
+```
+
+| Option | Required | Purpose |
+| --- | --- | --- |
+| `api_key` | yes | A send + receive mailbox key (`smx_mbx_*`) or a scoped agent token (`smx_agent_*`) |
+| `default_from` | no | Default sender for `send_email`. Without it, the model has to supply `var_from` on every call |
+
+## Retries and duplicate sends
+
+Agents retry. Pass `idempotency_key` on `send_email` and `reply` and Sendmux will send once, even if the same call arrives several times inside 24 hours. Any stable string works — a task id, a thread id, a hash of the message.
+
+Details: [idempotency](https://sendmux.ai/docs/guides/idempotency).
+
+## Common errors
+
+| What you see | Why | Fix |
+| --- | --- | --- |
+| `ValueError: No sender address` | No `var_from` on the call and no `default_from` set | Set `default_from`, or have the model pass `var_from` |
+| Send rejected on an agent token | The token is self-registered and not yet owner-approved | Complete the owner invite and approval |
+| Auth failure | Key lacks send or receive permission | Check the key's scope in the dashboard |
+
+## Related
+
+- [Quickstart](https://sendmux.ai/docs/guides/quickstart)
+- [Mailboxes](https://sendmux.ai/docs/guides/mailboxes)
+- [All Sendmux SDKs](https://sendmux.ai/docs/sdks)
+- [Pricing](https://sendmux.ai/pricing/) — usage-based, no per-seat or per-mailbox fees
 
 ## Licence
 

--- a/packages/python/langchain/pyproject.toml
+++ b/packages/python/langchain/pyproject.toml
@@ -9,6 +9,22 @@ description = "LangChain toolkit for the Sendmux email API for AI agents."
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
+keywords = [
+  "sendmux",
+  "email",
+  "email-api",
+  "ai-agents",
+  "agent",
+  "agents",
+  "langchain",
+  "langchain-toolkit",
+  "tools",
+  "inbox",
+  "mailbox",
+  "send-email",
+  "transactional-email",
+  "llm",
+]
 classifiers = [
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3",
@@ -24,7 +40,10 @@ dependencies = [
 ]
 
 [project.urls]
+Homepage = "https://sendmux.ai"
+Documentation = "https://sendmux.ai/docs/sdks"
 Repository = "https://github.com/Sendmux/sendmux-sdk"
+Issues = "https://github.com/Sendmux/sendmux-sdk/issues"
 
 [tool.hatch.build.targets.sdist]
 core-metadata-version = "2.4"

--- a/packages/ts/ai-sdk/README.md
+++ b/packages/ts/ai-sdk/README.md
@@ -1,6 +1,13 @@
 # @sendmux/ai-sdk
 
-[Vercel AI SDK](https://ai-sdk.dev) tools for [Sendmux](https://sendmux.ai), the email API for AI agents. Give an agent tools to send email and read its own inbox.
+[Vercel AI SDK](https://ai-sdk.dev) tools for [Sendmux](https://sendmux.ai), the email API for AI agents.
+
+Gives an agent its own mailbox: it can send email, read what arrives, and reply from its own address.
+
+## Requirements
+
+- Node.js 18 or newer
+- `ai` v5 and `zod` (peer dependencies — you already install `ai` to call `generateText`)
 
 ## Installation
 
@@ -8,34 +15,103 @@
 npm install @sendmux/ai-sdk ai zod
 ```
 
-`ai` and `zod` are peer dependencies (you already install `ai` to use `generateText`).
+## Getting an API key
 
-## Usage
+The tools need a key that can both send and receive. Two ways to get one:
+
+- **Dashboard** — create a mailbox and a mailbox-scoped key (`smx_mbx_*`). See [API keys](https://sendmux.ai/docs/guides/api-keys).
+- **Agent self-registration** — the agent claims its own `@myagent.mx` mailbox and gets an `smx_agent_*` token, with no human signup first. See [email for AI agents](https://sendmux.ai/solutions/for-ai-agents/).
+
+Note on agent tokens: a freshly self-registered `smx_agent_*` token can read and receive, but **cannot send** until a human owner has been invited and has approved it. Until then `send_email` and `reply` will fail. A dashboard `smx_mbx_*` key with send permission works immediately.
+
+Read the key from the environment. Never hard-code it.
+
+## Quick start
 
 ```ts
-import { generateText } from "ai";
 import { openai } from "@ai-sdk/openai";
+import { generateText } from "ai";
+
 import { sendmux } from "@sendmux/ai-sdk";
 
 const { text } = await generateText({
   model: openai("gpt-4o"),
-  tools: sendmux({ apiKey: process.env.SENDMUX_API_KEY! }),
-  prompt: "Reply to the latest invoice thread.",
+  tools: sendmux({
+    apiKey: process.env.SENDMUX_API_KEY!,
+    defaultFrom: "agent@yourdomain.dev",
+  }),
+  prompt: "Read the inbox and reply to anyone asking about pricing.",
 });
 ```
 
 ## Tools
 
-`sendmux(config)` returns a Vercel AI SDK `ToolSet` with three tools:
+`sendmux(config)` returns a Vercel AI SDK `ToolSet` with three tools.
 
-- `send_email` - send an email to any recipient through Sendmux.
-- `list_messages` - list recent messages in the agent's mailbox.
-- `reply` - send a message from the agent's own mailbox.
+### `send_email`
+
+Sends through your configured sending providers, to any recipient.
+
+| Parameter | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `to` | string | yes | Recipient email address |
+| `subject` | string | yes | Subject line |
+| `text` | string | yes | Plain-text body |
+| `html` | string | no | HTML body. Generated from `text` if omitted |
+| `from` | string | no | Sender address. Falls back to `defaultFrom` |
+| `idempotencyKey` | string | no | Makes a retried send idempotent for 24 hours |
+
+### `list_messages`
+
+Lists messages in the agent's own mailbox, newest first.
+
+| Parameter | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `limit` | integer | no | How many to return, 1 to 100 |
+
+### `reply`
+
+Sends from the agent's own mailbox address, rather than through a sending provider. Use this to answer someone who wrote in.
+
+| Parameter | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `to` | string | yes | Recipient email address |
+| `subject` | string | yes | Subject line |
+| `text` | string | yes | Plain-text body |
+| `html` | string | no | HTML body. Generated from `text` if omitted |
+| `idempotencyKey` | string | no | Makes a retried send idempotent for 24 hours |
 
 ## Configuration
 
-- `apiKey` (required) - a send + receive capable mailbox API key (`smx_mbx_*`) or a scoped agent token.
-- `defaultFrom` (optional) - default From address for `send_email` when a call omits `from`.
+```ts
+sendmux({ apiKey, defaultFrom });
+```
+
+| Option | Required | Purpose |
+| --- | --- | --- |
+| `apiKey` | yes | A send + receive mailbox key (`smx_mbx_*`) or a scoped agent token (`smx_agent_*`) |
+| `defaultFrom` | no | Default sender for `send_email`. Without it, the model has to supply `from` on every call |
+
+## Retries and duplicate sends
+
+Agents retry. Pass `idempotencyKey` on `send_email` and `reply` and Sendmux will send once, even if the same call arrives several times inside 24 hours. Any stable string works — a task id, a thread id, a hash of the message.
+
+Details: [idempotency](https://sendmux.ai/docs/guides/idempotency).
+
+## Common errors
+
+| What you see | Why | Fix |
+| --- | --- | --- |
+| `No sender address` | No `from` on the call and no `defaultFrom` set | Set `defaultFrom`, or have the model pass `from` |
+| Send rejected on an agent token | The token is self-registered and not yet owner-approved | Complete the owner invite and approval |
+| Auth failure | Key lacks send or receive permission | Check the key's scope in the dashboard |
+
+## Related
+
+- [Quickstart](https://sendmux.ai/docs/guides/quickstart)
+- [Mailboxes](https://sendmux.ai/docs/guides/mailboxes)
+- [All Sendmux SDKs](https://sendmux.ai/docs/sdks)
+- [Pricing](https://sendmux.ai/pricing/) — usage-based, no per-seat or per-mailbox fees
 
 ## Licence
 

--- a/packages/ts/ai-sdk/package.json
+++ b/packages/ts/ai-sdk/package.json
@@ -3,6 +3,24 @@
   "version": "0.3.0",
   "license": "MIT",
   "description": "Vercel AI SDK tools for the Sendmux email API for AI agents - send email and read the agent inbox.",
+  "keywords": [
+    "sendmux",
+    "email",
+    "email-api",
+    "ai-agents",
+    "agent",
+    "agents",
+    "ai-sdk",
+    "vercel-ai-sdk",
+    "tools",
+    "toolset",
+    "inbox",
+    "mailbox",
+    "send-email",
+    "transactional-email",
+    "llm"
+  ],
+  "homepage": "https://sendmux.ai",
   "type": "module",
   "exports": {
     ".": {
@@ -34,6 +52,9 @@
     "type": "git",
     "url": "git+https://github.com/Sendmux/sendmux-sdk.git",
     "directory": "packages/ts/ai-sdk"
+  },
+  "bugs": {
+    "url": "https://github.com/Sendmux/sendmux-sdk/issues"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
`@sendmux/ai-sdk` and `langchain-sendmux` both published on 2026-07-22 with **no keywords, no homepage, and ~1.2K-char READMEs**. Keywords are the main search lever on npm and PyPI, and both registries render the README from the *published* artefact, so neither reaches a user without a release.

Typed `fix` rather than `docs` on purpose — a `docs` commit does not bump, and unbumped metadata never ships.

## Metadata

| Package | Before | After |
| --- | --- | --- |
| `@sendmux/ai-sdk` | 0 keywords, no homepage, no bugs URL | 15 keywords, homepage, bugs URL |
| `langchain-sendmux` | 0 keywords, repo URL only | 14 keywords, Homepage / Documentation / Repository / Issues |

## READMEs

Both now cover requirements, how to obtain a key, a working quick start, a per-tool parameter table, configuration, idempotency, and a common-errors table.

Every parameter is read from the package source rather than restated from the old README, which is how these got documented for the first time:

- `send_email` and `reply` take an optional idempotency key (24-hour window)
- `html` is generated from `text` when omitted
- Python spells the sender `var_from`, because `from` is reserved
- `list_messages` accepts `limit` 1–100; Python defaults it to 25

Both also now state that a self-registered `smx_agent_*` token can read and receive but **cannot send until an owner approves it**. That is the first failure a developer hits with an agent token, and neither README mentioned it.

## Verification

- 11/11 README links resolve (200)
- `twine check` **passed** on the built sdist, so the README renders on PyPI
- `PKG-INFO` carries the keywords and all four project URLs
- `pnpm normalize:check` clean; both packages build

## Note for the reviewer

**No other package in this repo has keywords or a homepage** — all 7 npm and all 7 Python packages are missing them. This PR fixes only the two named in the task. The other 12 are worth a follow-up batch.

https://claude.ai/code/session_017EtuMTgt9aTthVejYRgtpU

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR improves the registry discoverability and published documentation of the two framework-wrapper packages.
- Adds keywords and project links for `@sendmux/ai-sdk` and `langchain-sendmux`.
- Expands both READMEs with setup guidance, tool parameters, configuration, idempotency behavior, and common errors.
- Documents the approval requirement for newly self-registered agent tokens.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up-review scope.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/python/langchain/README.md | Expands the LangChain wrapper documentation with installation, authentication, examples, tool contracts, retry guidance, and troubleshooting. |
| packages/python/langchain/pyproject.toml | Adds valid PyPI discovery keywords and project URLs while retaining the existing build and dependency configuration. |
| packages/ts/ai-sdk/README.md | Expands the AI SDK wrapper documentation with installation, authentication, examples, tool contracts, retry guidance, and troubleshooting. |
| packages/ts/ai-sdk/package.json | Adds valid npm keywords, homepage metadata, and an issue-tracker URL without changing the package runtime surface. |

<sub>Reviews (2): Last reviewed commit: ["fix(packages): add registry metadata and..."](https://github.com/sendmux/sendmux-sdk/commit/7409cc84bbd1902c4def75ba91a624969f8f2bd0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51084049)</sub>

**Context used:**

- Knowledge Base — [AI Agent Integrations (`@sendmux/ai-sdk`, `langchain-sendmux`)](https://app.greptile.com/jonahnz/-/custom-context/knowledge-base/sendmux/sendmux-sdk/-/docs/ai-agent-integrations.md)

<!-- /greptile_comment -->