### PR TITLE
[codex] Sync generated SDKs with current OpenAPI

### DIFF
--- a/go/management/error_methods.go
+++ b/go/management/error_methods.go
@@ -152,6 +152,12 @@ func (r *ManagementCreateSharedAmazonSesLimitRequestConflict) APIError() *core.A
 	return err
 }
 
+// APIError maps ManagementCreateSharedAmazonSesLimitRequestForbidden into the shared typed API error.
+func (r *ManagementCreateSharedAmazonSesLimitRequestForbidden) APIError() *core.APIError {
+	err, _ := core.APIErrorFromResponse(&r.Response, 403)
+	return err
+}
+
 // APIError maps ManagementCreateSharedAmazonSesLimitRequestNotFound into the shared typed API error.
 func (r *ManagementCreateSharedAmazonSesLimitRequestNotFound) APIError() *core.APIError {
 	err, _ := core.APIErrorFromResponse(&r.Response, 404)
@@ -491,6 +497,12 @@ func (r *ManagementListWebhooksUnauthorized) APIError() *core.APIError {
 // APIError maps ManagementRequestSendingAccountLimitIncreaseConflict into the shared typed API error.
 func (r *ManagementRequestSendingAccountLimitIncreaseConflict) APIError() *core.APIError {
 	err, _ := core.APIErrorFromResponse(&r.Response, 409)
+	return err
+}
+
+// APIError maps ManagementRequestSendingAccountLimitIncreaseForbidden into the shared typed API error.
+func (r *ManagementRequestSendingAccountLimitIncreaseForbidden) APIError() *core.APIError {
+	err, _ := core.APIErrorFromResponse(&r.Response, 403)
 	return err
 }
 

--- a/go/management/oas_response_decoders_gen.go
+++ b/go/management/oas_response_decoders_gen.go
@@ -2740,6 +2740,90 @@ func decodeManagementCreateSharedAmazonSesLimitRequestResponse(resp *http.Respon
 		default:
 			return res, validate.InvalidContentType(ct)
 		}
+	case 403:
+		// Code 403.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response ApiError
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			// Validate response.
+			if err := func() error {
+				if err := response.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return res, errors.Wrap(err, "validate")
+			}
+			var wrapper ManagementCreateSharedAmazonSesLimitRequestForbidden
+			wrapper.Response = response
+			h := uri.NewHeaderDecoder(resp.Header)
+			// Parse "Retry-After" header.
+			{
+				cfg := uri.HeaderParameterDecodingConfig{
+					Name:    "Retry-After",
+					Explode: false,
+				}
+				if err := func() error {
+					if err := h.HasParam(cfg); err == nil {
+						if err := h.DecodeParam(cfg, func(d uri.Decoder) error {
+							var wrapperDotRetryAfterVal int
+							if err := func() error {
+								val, err := d.DecodeValue()
+								if err != nil {
+									return err
+								}
+
+								c, err := conv.ToInt(val)
+								if err != nil {
+									return err
+								}
+
+								wrapperDotRetryAfterVal = c
+								return nil
+							}(); err != nil {
+								return err
+							}
+							wrapper.RetryAfter.SetTo(wrapperDotRetryAfterVal)
+							return nil
+						}); err != nil {
+							return err
+						}
+					}
+					return nil
+				}(); err != nil {
+					return res, errors.Wrap(err, "parse Retry-After header")
+				}
+			}
+			return &wrapper, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	case 404:
 		// Code 404.
 		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
@@ -10588,6 +10672,90 @@ func decodeManagementRequestSendingAccountLimitIncreaseResponse(resp *http.Respo
 				return res, errors.Wrap(err, "validate")
 			}
 			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 403:
+		// Code 403.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response ApiError
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			// Validate response.
+			if err := func() error {
+				if err := response.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return res, errors.Wrap(err, "validate")
+			}
+			var wrapper ManagementRequestSendingAccountLimitIncreaseForbidden
+			wrapper.Response = response
+			h := uri.NewHeaderDecoder(resp.Header)
+			// Parse "Retry-After" header.
+			{
+				cfg := uri.HeaderParameterDecodingConfig{
+					Name:    "Retry-After",
+					Explode: false,
+				}
+				if err := func() error {
+					if err := h.HasParam(cfg); err == nil {
+						if err := h.DecodeParam(cfg, func(d uri.Decoder) error {
+							var wrapperDotRetryAfterVal int
+							if err := func() error {
+								val, err := d.DecodeValue()
+								if err != nil {
+									return err
+								}
+
+								c, err := conv.ToInt(val)
+								if err != nil {
+									return err
+								}
+
+								wrapperDotRetryAfterVal = c
+								return nil
+							}(); err != nil {
+								return err
+							}
+							wrapper.RetryAfter.SetTo(wrapperDotRetryAfterVal)
+							return nil
+						}); err != nil {
+							return err
+						}
+					}
+					return nil
+				}(); err != nil {
+					return res, errors.Wrap(err, "parse Retry-After header")
+				}
+			}
+			return &wrapper, nil
 		default:
 			return res, validate.InvalidContentType(ct)
 		}

--- a/go/management/oas_response_encoders_gen.go
+++ b/go/management/oas_response_encoders_gen.go
@@ -1078,6 +1078,38 @@ func encodeManagementCreateSharedAmazonSesLimitRequestResponse(response Manageme
 
 		return nil
 
+	case *ManagementCreateSharedAmazonSesLimitRequestForbidden:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "Retry-After" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "Retry-After",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.RetryAfter.Get(); ok {
+						return e.EncodeValue(conv.IntToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode Retry-After header")
+				}
+			}
+		}
+		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
+
+		e := new(jx.Encoder)
+		response.Response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
 	case *ManagementCreateSharedAmazonSesLimitRequestNotFound:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		// Encoding response headers.
@@ -4187,6 +4219,38 @@ func encodeManagementRequestSendingAccountLimitIncreaseResponse(response Managem
 
 		e := new(jx.Encoder)
 		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *ManagementRequestSendingAccountLimitIncreaseForbidden:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "Retry-After" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "Retry-After",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.RetryAfter.Get(); ok {
+						return e.EncodeValue(conv.IntToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode Retry-After header")
+				}
+			}
+		}
+		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
+
+		e := new(jx.Encoder)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}

--- a/go/management/oas_schemas_gen.go
+++ b/go/management/oas_schemas_gen.go
@@ -5486,6 +5486,11 @@ type ManagementCreateSharedAmazonSesLimitRequestConflict ApiErrorHeaders
 func (*ManagementCreateSharedAmazonSesLimitRequestConflict) managementCreateSharedAmazonSesLimitRequestRes() {
 }
 
+type ManagementCreateSharedAmazonSesLimitRequestForbidden ApiErrorHeaders
+
+func (*ManagementCreateSharedAmazonSesLimitRequestForbidden) managementCreateSharedAmazonSesLimitRequestRes() {
+}
+
 type ManagementCreateSharedAmazonSesLimitRequestNotFound ApiErrorHeaders
 
 func (*ManagementCreateSharedAmazonSesLimitRequestNotFound) managementCreateSharedAmazonSesLimitRequestRes() {
@@ -6449,6 +6454,11 @@ func (*ManagementListWebhooksUnauthorized) managementListWebhooksRes() {}
 type ManagementRequestSendingAccountLimitIncreaseConflict ApiErrorHeaders
 
 func (*ManagementRequestSendingAccountLimitIncreaseConflict) managementRequestSendingAccountLimitIncreaseRes() {
+}
+
+type ManagementRequestSendingAccountLimitIncreaseForbidden ApiErrorHeaders
+
+func (*ManagementRequestSendingAccountLimitIncreaseForbidden) managementRequestSendingAccountLimitIncreaseRes() {
 }
 
 type ManagementRequestSendingAccountLimitIncreaseUnprocessableEntity ApiErrorHeaders

--- a/go/management/oas_validators_gen.go
+++ b/go/management/oas_validators_gen.go
@@ -2939,6 +2939,14 @@ func (s *ManagementCreateSharedAmazonSesLimitRequestConflict) Validate() error {
 	return nil
 }
 
+func (s *ManagementCreateSharedAmazonSesLimitRequestForbidden) Validate() error {
+	alias := (*ApiErrorHeaders)(s)
+	if err := alias.Validate(); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (s *ManagementCreateSharedAmazonSesLimitRequestNotFound) Validate() error {
 	alias := (*ApiErrorHeaders)(s)
 	if err := alias.Validate(); err != nil {
@@ -3545,6 +3553,14 @@ func (s *ManagementListWebhooksUnauthorized) Validate() error {
 }
 
 func (s *ManagementRequestSendingAccountLimitIncreaseConflict) Validate() error {
+	alias := (*ApiErrorHeaders)(s)
+	if err := alias.Validate(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *ManagementRequestSendingAccountLimitIncreaseForbidden) Validate() error {
 	alias := (*ApiErrorHeaders)(s)
 	if err := alias.Validate(); err != nil {
 		return err

--- a/packages/php/management/src/Api/SendingAccountsApi.php
+++ b/packages/php/management/src/Api/SendingAccountsApi.php
@@ -1254,7 +1254,7 @@ class SendingAccountsApi
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
      * @throws InvalidArgumentException
-     * @return array of \Sendmux\Management\Model\SharedAmazonSesLimitRequestCreateResponse|\Sendmux\Management\Model\ApiError|\Sendmux\Management\Model\ApiError|\Sendmux\Management\Model\ApiError, HTTP status code, HTTP response headers (array of strings)
+     * @return array of \Sendmux\Management\Model\SharedAmazonSesLimitRequestCreateResponse|\Sendmux\Management\Model\ApiError|\Sendmux\Management\Model\ApiError|\Sendmux\Management\Model\ApiError|\Sendmux\Management\Model\ApiError, HTTP status code, HTTP response headers (array of strings)
      */
     public function managementCreateSharedAmazonSesLimitRequestWithHttpInfo(
         ?string $idempotency_key = null,
@@ -1291,6 +1291,12 @@ class SendingAccountsApi
                 case 200:
                     return $this->handleResponseWithDataType(
                         '\Sendmux\Management\Model\SharedAmazonSesLimitRequestCreateResponse',
+                        $request,
+                        $response,
+                    );
+                case 403:
+                    return $this->handleResponseWithDataType(
+                        '\Sendmux\Management\Model\ApiError',
                         $request,
                         $response,
                     );
@@ -1339,6 +1345,14 @@ class SendingAccountsApi
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
                         '\Sendmux\Management\Model\SharedAmazonSesLimitRequestCreateResponse',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    throw $e;
+                case 403:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        '\Sendmux\Management\Model\ApiError',
                         $e->getResponseHeaders()
                     );
                     $e->setResponseObject($data);
@@ -4173,7 +4187,7 @@ class SendingAccountsApi
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
      * @throws InvalidArgumentException
-     * @return array of \Sendmux\Management\Model\SendingAccountLimitRequestResponse|\Sendmux\Management\Model\ApiError|\Sendmux\Management\Model\ApiError, HTTP status code, HTTP response headers (array of strings)
+     * @return array of \Sendmux\Management\Model\SendingAccountLimitRequestResponse|\Sendmux\Management\Model\ApiError|\Sendmux\Management\Model\ApiError|\Sendmux\Management\Model\ApiError, HTTP status code, HTTP response headers (array of strings)
      */
     public function managementRequestSendingAccountLimitIncreaseWithHttpInfo(
         ?string $idempotency_key = null,
@@ -4210,6 +4224,12 @@ class SendingAccountsApi
                 case 200:
                     return $this->handleResponseWithDataType(
                         '\Sendmux\Management\Model\SendingAccountLimitRequestResponse',
+                        $request,
+                        $response,
+                    );
+                case 403:
+                    return $this->handleResponseWithDataType(
+                        '\Sendmux\Management\Model\ApiError',
                         $request,
                         $response,
                     );
@@ -4252,6 +4272,14 @@ class SendingAccountsApi
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
                         '\Sendmux\Management\Model\SendingAccountLimitRequestResponse',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    throw $e;
+                case 403:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        '\Sendmux\Management\Model\ApiError',
                         $e->getResponseHeaders()
                     );
                     $e->setResponseObject($data);

--- a/packages/python/management/sendmux_management/api/sending_accounts_api.py
+++ b/packages/python/management/sendmux_management/api/sending_accounts_api.py
@@ -952,6 +952,7 @@ class SendingAccountsApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "SharedAmazonSesLimitRequestCreateResponse",
+            '403': "ApiError",
             '404': "ApiError",
             '409': "ApiError",
             '422': "ApiError",
@@ -1022,6 +1023,7 @@ class SendingAccountsApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "SharedAmazonSesLimitRequestCreateResponse",
+            '403': "ApiError",
             '404': "ApiError",
             '409': "ApiError",
             '422': "ApiError",
@@ -1092,6 +1094,7 @@ class SendingAccountsApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "SharedAmazonSesLimitRequestCreateResponse",
+            '403': "ApiError",
             '404': "ApiError",
             '409': "ApiError",
             '422': "ApiError",
@@ -3363,6 +3366,7 @@ class SendingAccountsApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "SendingAccountLimitRequestResponse",
+            '403': "ApiError",
             '409': "ApiError",
             '422': "ApiError",
         }
@@ -3432,6 +3436,7 @@ class SendingAccountsApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "SendingAccountLimitRequestResponse",
+            '403': "ApiError",
             '409': "ApiError",
             '422': "ApiError",
         }
@@ -3501,6 +3506,7 @@ class SendingAccountsApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "SendingAccountLimitRequestResponse",
+            '403': "ApiError",
             '409': "ApiError",
             '422': "ApiError",
         }

--- a/packages/python/mcp/sendmux_mcp/openapi/openapi-app.json
+++ b/packages/python/mcp/sendmux_mcp/openapi/openapi-app.json
@@ -15853,6 +15853,16 @@
             },
             "description": "Request submitted"
           },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Free plan limits are fixed; upgrade to Pro to add more sending accounts"
+          },
           "409": {
             "content": {
               "application/json": {
@@ -15937,6 +15947,16 @@
               }
             },
             "description": "Request submitted"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Free plan limits are fixed; upgrade to Pro to increase the managed sending limit"
           },
           "404": {
             "content": {

--- a/packages/python/mcp/sendmux_mcp/openapi/openapi-sending.json
+++ b/packages/python/mcp/sendmux_mcp/openapi/openapi-sending.json
@@ -1328,7 +1328,7 @@
                 }
               }
             },
-            "description": "Rate limit exceeded (Retry-After header included)"
+            "description": "Rate limit exceeded or Free daily sending limit reached (Retry-After header included)"
           },
           "503": {
             "content": {
@@ -1468,7 +1468,7 @@
                 }
               }
             },
-            "description": "Rate limit exceeded"
+            "description": "Rate limit exceeded or Free daily sending limit reached (Retry-After header included)"
           },
           "503": {
             "content": {

--- a/packages/ts/management/src/generated/types.gen.ts
+++ b/packages/ts/management/src/generated/types.gen.ts
@@ -3137,6 +3137,10 @@ export type ManagementRequestSendingAccountLimitIncreaseData = {
 
 export type ManagementRequestSendingAccountLimitIncreaseErrors = {
     /**
+     * Free plan limits are fixed; upgrade to Pro to add more sending accounts
+     */
+    403: ApiError;
+    /**
      * A request is already pending
      */
     409: ApiError;
@@ -3187,6 +3191,10 @@ export type ManagementCreateSharedAmazonSesLimitRequestData = {
 };
 
 export type ManagementCreateSharedAmazonSesLimitRequestErrors = {
+    /**
+     * Free plan limits are fixed; upgrade to Pro to increase the managed sending limit
+     */
+    403: ApiError;
     /**
      * Shared Amazon SES account not found
      */

--- a/packages/ts/sending/src/generated/types.gen.ts
+++ b/packages/ts/sending/src/generated/types.gen.ts
@@ -579,7 +579,7 @@ export type SendingSendEmailErrors = {
      */
     422: ErrorResponse;
     /**
-     * Rate limit exceeded (Retry-After header included)
+     * Rate limit exceeded or Free daily sending limit reached (Retry-After header included)
      */
     429: ErrorResponse;
     /**
@@ -642,7 +642,7 @@ export type SendingSendEmailBatchErrors = {
      */
     422: ErrorResponse;
     /**
-     * Rate limit exceeded
+     * Rate limit exceeded or Free daily sending limit reached (Retry-After header included)
      */
     429: ErrorResponse;
     /**


### PR DESCRIPTION
## What changed

- Regenerated the Go, TypeScript, Python, and PHP SDK output from docs commit `1e8e383`.
- Refreshed the MCP OpenAPI snapshots.
- Added generated error handling for Free plan limits and updated the sending limit descriptions.

## Why

The current OpenAPI snapshots had moved ahead of the committed SDK output. New SDK pull requests failed the drift gate before reaching their own checks.

## Impact

Generated clients now match the current API contract. This PR does not change handwritten runtime behaviour.

## Checks

- `pnpm build`
- `git diff --cached --check`
