### PR TITLE
feat(cli): add durable agent onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,10 @@ For command-line access, install the CLI:
 ```sh
 brew install sendmux/tap/sendmux
 npm install -g @sendmux/cli
-sendmux --help
+sendmux agent:register my-agent --mailbox-local-part my-agent --default --json
 ```
+
+Agent registration does not require an existing account or API key. It creates a local profile with a durable, revocable credential for reading and receiving mail. To send, invite the owner with `sendmux agent:invite-owner owner@example.com --profile my-agent`; after the owner accepts and approves sending, Sending API commands exchange and cache a one-hour delegated token automatically.
 
 For MCP clients, install `sendmux-mcp` or connect to the hosted MCP endpoint:
 

--- a/packages/ts/cli/README.md
+++ b/packages/ts/cli/README.md
@@ -17,10 +17,11 @@ Agent-drivable command line interface for Sendmux.
 
 ## Requirements
 
+- No existing Sendmux account or API key is required to register an agent inbox.
 - npm global installs, `npx`, or a downloaded release tarball.
 - A root `smx_root_*` key for Management commands.
-- A send-capable `smx_mbx_*` key or owner-approved Sending-resource `smx_agent_*` token for Sending commands.
-- A mailbox-scoped `smx_mbx_*` key or scoped `smx_agent_*` token for Mailbox commands. Agent tokens remain limited by server-side scopes; pre-claim self-registered agent tokens do not include `email.send`.
+- A send-capable `smx_mbx_*` key or owner-approved agent profile for Sending commands.
+- A mailbox-scoped `smx_mbx_*` key or registered agent profile for Mailbox commands.
 
 ## Installation
 
@@ -32,7 +33,41 @@ The package exposes the `sendmux` binary.
 
 ## Usage
 
-Create profiles for each key type before running API commands.
+Register an agent inbox and save its durable read credential in a local profile:
+
+```sh
+sendmux agent:register my-agent \
+  --mailbox-local-part my-agent \
+  --client-name "My agent" \
+  --default \
+  --json
+```
+
+The registration result never prints the credential. The profile can read and receive mail without an expiry date, unless the registration is fully revoked. Inbox readiness may take a moment; the command waits for provisioning for up to 10 minutes and can be rerun safely with the same profile.
+
+Read the inbox from any later process:
+
+```sh
+sendmux mailbox:messages:list --profile my-agent --query limit=25 --json
+```
+
+To enable sending, invite the inbox owner either during registration with `--owner-email` or afterward:
+
+```sh
+sendmux agent:invite-owner owner@example.com --profile my-agent --json
+```
+
+The owner must accept the invitation and approve sending. After approval, Sending API commands automatically exchange the durable read credential for a one-hour `email.send` token and reuse it until it approaches expiry:
+
+```sh
+sendmux sending:send \
+  --profile my-agent \
+  --idempotency-key "$IDEMPOTENCY_KEY" \
+  --body '{"from":{"email":"sender@example.com"},"to":{"email":"recipient@example.com"},"subject":"Hello","text_body":"Hello"}' \
+  --json
+```
+
+Existing Sendmux users can continue creating API-key profiles:
 
 ```sh
 sendmux profiles:set default --api-key smx_root_... --default
@@ -103,6 +138,7 @@ The CLI includes `97` generated API operation commands:
 - `41` Mailbox commands, including `mailbox:messages:list`, `mailbox:messages:get`, `mailbox:send-message`, and `mailbox:list-granted-mailboxes`.
 - `53` Management commands, including `management:domains:list`, `management:create-mailbox`, `management:get-spend-summary`, and `management:create-webhook`.
 - `3` Sending commands: `sending:get-open-api-spec`, `sending:send`, and `sending:send:batch`.
+- Agent onboarding commands: `agent:register` and `agent:invite-owner`.
 - Profile commands: `profiles:list`, `profiles:set`, and `profiles:show`.
 
 Use command-level help for required path, query, header, and body fields.

--- a/packages/ts/cli/package.json
+++ b/packages/ts/cli/package.json
@@ -44,6 +44,9 @@
     "commands": "./dist/commands",
     "topicSeparator": ":",
     "topics": {
+      "agent": {
+        "description": "Register and link agent inboxes"
+      },
       "mailbox": {
         "description": "Mailbox API commands"
       },

--- a/packages/ts/cli/src/agent-auth.ts
+++ b/packages/ts/cli/src/agent-auth.ts
@@ -1,8 +1,11 @@
 import { randomUUID } from "node:crypto";
+import { isIP } from "node:net";
 
 import {
+  clearAgentRegistrationIntent,
   isActiveAgentProfile,
   readCliConfig,
+  reserveAgentRegistrationIntent,
   type ActiveAgentCliProfile,
   type AgentCliProfile,
   type CliConfig,
@@ -47,7 +50,7 @@ export interface SafeAgentRegistrationResult {
 }
 
 export async function registerAgent(input: RegisterAgentInput): Promise<SafeAgentRegistrationResult> {
-  const config = await readCliConfig(input.configDir);
+  let config = await readCliConfig(input.configDir);
   const existing = config.profiles[input.profileName];
   let activeProfile: ActiveAgentCliProfile;
 
@@ -58,36 +61,61 @@ export async function registerAgent(input: RegisterAgentInput): Promise<SafeAgen
       config.defaultProfile = input.profileName;
       await writeCliConfig(input.configDir, config);
     }
+    await clearAgentRegistrationIntent(input.configDir, input.profileName);
   } else {
-    const registering = registrationIntent({ existing, input });
-    config.profiles[input.profileName] = registering;
-    if (input.makeDefault || !config.defaultProfile) {
-      config.defaultProfile = input.profileName;
+    const candidate = registrationIntent({ existing, input });
+    const registering = await reserveAgentRegistrationIntent(input.configDir, input.profileName, candidate);
+    assertMatchingRegistration(registering, input);
+
+    config = await readCliConfig(input.configDir);
+    const latestExisting = config.profiles[input.profileName];
+    if (latestExisting && isActiveAgentProfile(latestExisting)) {
+      assertMatchingRegistration(latestExisting, input);
+      activeProfile = latestExisting;
+      if (input.makeDefault || !config.defaultProfile) {
+        config.defaultProfile = input.profileName;
+        await writeCliConfig(input.configDir, config);
+      }
+      await clearAgentRegistrationIntent(input.configDir, input.profileName);
+    } else {
+      if (latestExisting) {
+        if (latestExisting.type !== "agent" || latestExisting.state !== "registering") {
+          throw new Error(`Sendmux profile "${input.profileName}" already exists and is not an agent profile.`);
+        }
+        if (latestExisting.idempotencyKey !== registering.idempotencyKey) {
+          throw new Error(`Sendmux agent profile "${input.profileName}" belongs to a different registration request.`);
+        }
+      }
+      config.profiles[input.profileName] = registering;
+      if (input.makeDefault || !config.defaultProfile) {
+        config.defaultProfile = input.profileName;
+      }
+      await writeCliConfig(input.configDir, config);
+
+      const registration = await postJson<AgentRegistrationResponse>(`${registering.authBaseUrl}/agent/identity`, {
+        headers: { "Idempotency-Key": registering.idempotencyKey },
+        body: {
+          type: "anonymous",
+          ...(registering.mailboxLocalPart ? { mailbox_local_part: registering.mailboxLocalPart } : {}),
+          ...(registering.clientName ? { client_name: registering.clientName } : {}),
+          idempotency_key: registering.idempotencyKey,
+        },
+        expectedStatuses: [200, 201],
+      });
+      assertRegistrationResponse(registration);
+
+      const afterRegistration = await readCliConfig(input.configDir);
+      activeProfile = {
+        ...registering,
+        accessToken: registration.access_token,
+        mailboxEmail: registration.mailbox.email,
+        registrationId: registration.registration_id,
+        state: "active",
+      };
+      afterRegistration.profiles[input.profileName] = activeProfile;
+      await writeCliConfig(input.configDir, afterRegistration);
+      await clearAgentRegistrationIntent(input.configDir, input.profileName);
     }
-    await writeCliConfig(input.configDir, config);
-
-    const registration = await postJson<AgentRegistrationResponse>(`${registering.authBaseUrl}/agent/identity`, {
-      headers: { "Idempotency-Key": registering.idempotencyKey },
-      body: {
-        type: "anonymous",
-        ...(registering.mailboxLocalPart ? { mailbox_local_part: registering.mailboxLocalPart } : {}),
-        ...(registering.clientName ? { client_name: registering.clientName } : {}),
-        idempotency_key: registering.idempotencyKey,
-      },
-      expectedStatuses: [200, 201],
-    });
-    assertRegistrationResponse(registration);
-
-    const afterRegistration = await readCliConfig(input.configDir);
-    activeProfile = {
-      ...registering,
-      accessToken: registration.access_token,
-      mailboxEmail: registration.mailbox.email,
-      registrationId: registration.registration_id,
-      state: "active",
-    };
-    afterRegistration.profiles[input.profileName] = activeProfile;
-    await writeCliConfig(input.configDir, afterRegistration);
   }
 
   const reloaded = await activeAgentProfile(input.configDir, input.profileName);
@@ -230,16 +258,24 @@ function registrationIntent({
 }
 
 function assertMatchingRegistration(profile: AgentCliProfile, input: RegisterAgentInput): void {
-  const urls = agentUrls(input.appOrigin);
   if (
-    profile.appApiBaseUrl !== urls.appApiBaseUrl ||
-    profile.authBaseUrl !== urls.authBaseUrl ||
-    profile.sendingApiBaseUrl !== urls.sendingApiBaseUrl ||
-    profile.clientName !== input.clientName ||
-    profile.mailboxLocalPart !== input.mailboxLocalPart
+    (input.appOrigin !== undefined && !registrationUrlsMatch(profile, agentUrls(input.appOrigin))) ||
+    (input.clientName !== undefined && profile.clientName !== input.clientName) ||
+    (input.mailboxLocalPart !== undefined && profile.mailboxLocalPart !== input.mailboxLocalPart)
   ) {
     throw new Error(`Sendmux agent profile "${input.profileName}" belongs to a different registration request.`);
   }
+}
+
+function registrationUrlsMatch(
+  profile: AgentCliProfile,
+  urls: Pick<RegisteringAgentCliProfile, "appApiBaseUrl" | "authBaseUrl" | "sendingApiBaseUrl">,
+): boolean {
+  return (
+    profile.appApiBaseUrl === urls.appApiBaseUrl &&
+    profile.authBaseUrl === urls.authBaseUrl &&
+    profile.sendingApiBaseUrl === urls.sendingApiBaseUrl
+  );
 }
 
 function agentUrls(appOriginInput: string | undefined): Pick<RegisteringAgentCliProfile, "appApiBaseUrl" | "authBaseUrl" | "sendingApiBaseUrl"> {
@@ -252,7 +288,7 @@ function agentUrls(appOriginInput: string | undefined): Pick<RegisteringAgentCli
   };
 }
 
-function normaliseAppOrigin(value: string): string {
+export function normaliseAppOrigin(value: string): string {
   const url = new URL(value);
   if (!['http:', 'https:'].includes(url.protocol) || url.username || url.password || url.search || url.hash) {
     throw new Error("--base-url must be an HTTP(S) origin without credentials, query, or fragment.");
@@ -260,23 +296,62 @@ function normaliseAppOrigin(value: string): string {
   if (url.pathname !== "/") {
     throw new Error("--base-url must be an origin without a path.");
   }
+  if (url.protocol === "http:" && !isLoopbackHttpOrigin(value)) {
+    throw new Error("--base-url must use HTTPS unless it is a canonical loopback origin.");
+  }
   return url.origin;
 }
 
-async function waitForMailbox(profile: ActiveAgentCliProfile): Promise<void> {
-  const deadline = Date.now() + READINESS_TIMEOUT_MS;
+function isLoopbackHttpOrigin(value: string): boolean {
+  const authority = value.match(/^http:\/\/([^/?#]+)/i)?.[1];
+  if (!authority) return false;
+  const rawHostname = authority.startsWith("[")
+    ? authority.slice(1, authority.indexOf("]"))
+    : authority.split(":", 1)[0];
+  if (!rawHostname) return false;
+  if (rawHostname.toLowerCase() === "localhost" || rawHostname === "::1") return true;
+  return /^\d{1,3}(?:\.\d{1,3}){3}$/.test(rawHostname) && isIP(rawHostname) === 4 && rawHostname.split(".")[0] === "127";
+}
+
+export async function waitForMailbox(
+  profile: ActiveAgentCliProfile,
+  timeoutMs = READINESS_TIMEOUT_MS,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
   while (true) {
-    const response = await fetch(`${profile.appApiBaseUrl}/mailbox/me`, {
-      headers: { Authorization: `Bearer ${profile.accessToken}` },
-    });
+    const remainingBeforeFetch = deadline - Date.now();
+    if (remainingBeforeFetch <= 0) throw mailboxReadinessTimeoutError();
+
+    let response: Response;
+    try {
+      response = await fetch(`${profile.appApiBaseUrl}/mailbox/me`, {
+        headers: { Authorization: `Bearer ${profile.accessToken}` },
+        signal: AbortSignal.timeout(remainingBeforeFetch),
+      });
+    } catch (error) {
+      if (isAbortError(error) || Date.now() >= deadline) throw mailboxReadinessTimeoutError();
+      throw error;
+    }
     if (response.ok) return;
     const body = await responseJson(response);
-    if (response.status !== 503 || body.error !== "temporarily_unavailable" || Date.now() >= deadline) {
+    const provisioningUnavailable =
+      response.status === 503 && (body.error === "service_unavailable" || body.error === "temporarily_unavailable");
+    if (!provisioningUnavailable) {
       throw new Error(agentAuthFailureMessage(response.status, body));
     }
-    const retryAfter = retryAfterSeconds(response, body);
-    await new Promise((resolve) => setTimeout(resolve, retryAfter * 1_000));
+    const remainingBeforeRetry = deadline - Date.now();
+    if (remainingBeforeRetry <= 0) throw mailboxReadinessTimeoutError();
+    const retryDelayMs = Math.min(Math.max(retryAfterSeconds(response, body) * 1_000, 1_000), remainingBeforeRetry);
+    await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
   }
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
+}
+
+function mailboxReadinessTimeoutError(): Error {
+  return new Error("Agent mailbox provisioning did not finish within the allowed time.");
 }
 
 async function activeAgentProfile(configDir: string, profileName: string): Promise<ActiveAgentCliProfile> {
@@ -321,14 +396,14 @@ async function responseJson(response: Response): Promise<Record<string, unknown>
 
 function retryAfterSeconds(response: Response, body: Record<string, unknown>): number {
   const value = Number(response.headers.get("Retry-After") ?? body.retry_after ?? 10);
-  return Number.isFinite(value) && value >= 0 ? value : 10;
+  return Number.isFinite(value) && value > 0 ? value : 1;
 }
 
 function agentAuthFailureMessage(status: number, body: Record<string, unknown>): string {
   if (status === 503 && body.error === "authorization_pending") {
     return "Agent sending is awaiting owner acceptance or approval.";
   }
-  if (status === 503 && body.error === "temporarily_unavailable") {
+  if (status === 503 && (body.error === "service_unavailable" || body.error === "temporarily_unavailable")) {
     return "Agent mailbox provisioning did not finish within the allowed time.";
   }
   const description = typeof body.error_description === "string" ? body.error_description : null;

--- a/packages/ts/cli/src/agent-auth.ts
+++ b/packages/ts/cli/src/agent-auth.ts
@@ -1,0 +1,352 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  isActiveAgentProfile,
+  readCliConfig,
+  type ActiveAgentCliProfile,
+  type AgentCliProfile,
+  type CliConfig,
+  type RegisteringAgentCliProfile,
+  writeCliConfig,
+} from "./profiles.js";
+
+const DEFAULT_APP_ORIGIN = "https://app.sendmux.ai";
+const DEFAULT_SENDING_API_BASE_URL = "https://smtp.sendmux.ai/api/v1";
+const SENDING_API_RESOURCE = "https://smtp.sendmux.ai/api/v1";
+const TOKEN_EXCHANGE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange";
+const ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
+const READINESS_TIMEOUT_MS = 10 * 60 * 1_000;
+const SENDING_TOKEN_SKEW_MS = 60 * 1_000;
+
+interface RegisterAgentInput {
+  appOrigin?: string;
+  clientName?: string;
+  configDir: string;
+  makeDefault: boolean;
+  mailboxLocalPart?: string;
+  ownerEmail?: string;
+  profileName: string;
+}
+
+interface AgentRegistrationResponse {
+  access_token: string;
+  mailbox: {
+    email: string;
+    status: string;
+  };
+  registration_id: string;
+}
+
+export interface SafeAgentRegistrationResult {
+  default: boolean;
+  mailbox_email: string;
+  name: string;
+  owner_invite_status?: "pending";
+  registration_id: string;
+  status: "active";
+}
+
+export async function registerAgent(input: RegisterAgentInput): Promise<SafeAgentRegistrationResult> {
+  const config = await readCliConfig(input.configDir);
+  const existing = config.profiles[input.profileName];
+  let activeProfile: ActiveAgentCliProfile;
+
+  if (existing && isActiveAgentProfile(existing)) {
+    assertMatchingRegistration(existing, input);
+    activeProfile = existing;
+    if (input.makeDefault || !config.defaultProfile) {
+      config.defaultProfile = input.profileName;
+      await writeCliConfig(input.configDir, config);
+    }
+  } else {
+    const registering = registrationIntent({ existing, input });
+    config.profiles[input.profileName] = registering;
+    if (input.makeDefault || !config.defaultProfile) {
+      config.defaultProfile = input.profileName;
+    }
+    await writeCliConfig(input.configDir, config);
+
+    const registration = await postJson<AgentRegistrationResponse>(`${registering.authBaseUrl}/agent/identity`, {
+      headers: { "Idempotency-Key": registering.idempotencyKey },
+      body: {
+        type: "anonymous",
+        ...(registering.mailboxLocalPart ? { mailbox_local_part: registering.mailboxLocalPart } : {}),
+        ...(registering.clientName ? { client_name: registering.clientName } : {}),
+        idempotency_key: registering.idempotencyKey,
+      },
+      expectedStatuses: [200, 201],
+    });
+    assertRegistrationResponse(registration);
+
+    const afterRegistration = await readCliConfig(input.configDir);
+    activeProfile = {
+      ...registering,
+      accessToken: registration.access_token,
+      mailboxEmail: registration.mailbox.email,
+      registrationId: registration.registration_id,
+      state: "active",
+    };
+    afterRegistration.profiles[input.profileName] = activeProfile;
+    await writeCliConfig(input.configDir, afterRegistration);
+  }
+
+  const reloaded = await activeAgentProfile(input.configDir, input.profileName);
+  await waitForMailbox(reloaded);
+
+  let ownerInviteStatus: "pending" | undefined;
+  if (input.ownerEmail) {
+    await inviteAgentOwner({ configDir: input.configDir, email: input.ownerEmail, profileName: input.profileName });
+    ownerInviteStatus = "pending";
+  }
+
+  const finalConfig = await readCliConfig(input.configDir);
+  return {
+    default: finalConfig.defaultProfile === input.profileName,
+    mailbox_email: activeProfile.mailboxEmail,
+    name: input.profileName,
+    ...(ownerInviteStatus ? { owner_invite_status: ownerInviteStatus } : {}),
+    registration_id: activeProfile.registrationId,
+    status: "active",
+  };
+}
+
+export async function inviteAgentOwner({
+  configDir,
+  email,
+  profileName,
+}: {
+  configDir: string;
+  email: string;
+  profileName: string;
+}): Promise<{ email: string; status: "pending" }> {
+  const config = await readCliConfig(configDir);
+  const profile = activeAgentProfileFromConfig(config, profileName);
+  const existingInvite = profile.ownerInvite;
+  const idempotencyKey =
+    existingInvite?.email.toLowerCase() === email.toLowerCase() ? existingInvite.idempotencyKey : randomUUID();
+
+  config.profiles[profileName] = {
+    ...profile,
+    ownerInvite: { email, idempotencyKey, status: "dispatching" as const },
+  };
+  await writeCliConfig(configDir, config);
+
+  const reloaded = await activeAgentProfile(configDir, profileName);
+  await postJson(`${reloaded.authBaseUrl}/agent/identity/invite`, {
+    headers: {
+      Authorization: `Bearer ${reloaded.accessToken}`,
+      "Idempotency-Key": idempotencyKey,
+    },
+    body: { email, idempotency_key: idempotencyKey, requested_role: "owner" },
+    expectedStatuses: [200, 202],
+  });
+
+  const afterInvite = await readCliConfig(configDir);
+  const current = activeAgentProfileFromConfig(afterInvite, profileName);
+  afterInvite.profiles[profileName] = {
+    ...current,
+    ownerInvite: { email, idempotencyKey, status: "pending" as const },
+  };
+  await writeCliConfig(configDir, afterInvite);
+  return { email, status: "pending" };
+}
+
+export async function resolveAgentSendingToken({
+  config,
+  configDir,
+  profile,
+  profileName,
+}: {
+  config: CliConfig;
+  configDir: string;
+  profile: ActiveAgentCliProfile;
+  profileName: string;
+}): Promise<string> {
+  if (profile.sendingToken && Date.parse(profile.sendingToken.expiresAt) > Date.now() + SENDING_TOKEN_SKEW_MS) {
+    return profile.sendingToken.accessToken;
+  }
+
+  const response = await fetch(`${profile.authBaseUrl}/oauth2/token`, {
+    body: new URLSearchParams({
+      grant_type: TOKEN_EXCHANGE_GRANT_TYPE,
+      resource: SENDING_API_RESOURCE,
+      scope: "email.send",
+      subject_token: profile.accessToken,
+      subject_token_type: ACCESS_TOKEN_TYPE,
+    }),
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    method: "POST",
+  });
+  const body = await responseJson(response);
+  if (!response.ok) {
+    throw new Error(agentAuthFailureMessage(response.status, body));
+  }
+  const accessToken = requiredString(body, "access_token", "token exchange");
+  const expiresIn = body.expires_in;
+  if (typeof expiresIn !== "number" || !Number.isFinite(expiresIn) || expiresIn <= 0) {
+    throw new Error("Sendmux token exchange returned an invalid expiry.");
+  }
+
+  const latestConfig = await readCliConfig(configDir);
+  const latestProfile = activeAgentProfileFromConfig(latestConfig, profileName);
+  latestConfig.profiles[profileName] = {
+    ...latestProfile,
+    sendingToken: {
+      accessToken,
+      expiresAt: new Date(Date.now() + expiresIn * 1_000).toISOString(),
+    },
+  };
+  await writeCliConfig(configDir, latestConfig);
+  config.profiles[profileName] = latestConfig.profiles[profileName];
+  return accessToken;
+}
+
+function registrationIntent({
+  existing,
+  input,
+}: {
+  existing: CliConfig["profiles"][string] | undefined;
+  input: RegisterAgentInput;
+}): RegisteringAgentCliProfile {
+  const urls = agentUrls(input.appOrigin);
+  if (existing?.type === "agent") {
+    if (existing.state !== "registering") {
+      throw new Error(`Sendmux agent profile "${input.profileName}" is already active.`);
+    }
+    assertMatchingRegistration(existing, input);
+    return existing;
+  }
+  if (existing) {
+    throw new Error(`Sendmux profile "${input.profileName}" already exists and is not an agent profile.`);
+  }
+  return {
+    ...urls,
+    ...(input.clientName ? { clientName: input.clientName } : {}),
+    idempotencyKey: randomUUID(),
+    ...(input.mailboxLocalPart ? { mailboxLocalPart: input.mailboxLocalPart } : {}),
+    state: "registering",
+    type: "agent",
+  };
+}
+
+function assertMatchingRegistration(profile: AgentCliProfile, input: RegisterAgentInput): void {
+  const urls = agentUrls(input.appOrigin);
+  if (
+    profile.appApiBaseUrl !== urls.appApiBaseUrl ||
+    profile.authBaseUrl !== urls.authBaseUrl ||
+    profile.sendingApiBaseUrl !== urls.sendingApiBaseUrl ||
+    profile.clientName !== input.clientName ||
+    profile.mailboxLocalPart !== input.mailboxLocalPart
+  ) {
+    throw new Error(`Sendmux agent profile "${input.profileName}" belongs to a different registration request.`);
+  }
+}
+
+function agentUrls(appOriginInput: string | undefined): Pick<RegisteringAgentCliProfile, "appApiBaseUrl" | "authBaseUrl" | "sendingApiBaseUrl"> {
+  const customOrigin = appOriginInput ? normaliseAppOrigin(appOriginInput) : null;
+  const appOrigin = customOrigin ?? DEFAULT_APP_ORIGIN;
+  return {
+    appApiBaseUrl: `${appOrigin}/api/v1`,
+    authBaseUrl: `${appOrigin}/agent-auth`,
+    sendingApiBaseUrl: customOrigin ? `${customOrigin}/api/v1` : DEFAULT_SENDING_API_BASE_URL,
+  };
+}
+
+function normaliseAppOrigin(value: string): string {
+  const url = new URL(value);
+  if (!['http:', 'https:'].includes(url.protocol) || url.username || url.password || url.search || url.hash) {
+    throw new Error("--base-url must be an HTTP(S) origin without credentials, query, or fragment.");
+  }
+  if (url.pathname !== "/") {
+    throw new Error("--base-url must be an origin without a path.");
+  }
+  return url.origin;
+}
+
+async function waitForMailbox(profile: ActiveAgentCliProfile): Promise<void> {
+  const deadline = Date.now() + READINESS_TIMEOUT_MS;
+  while (true) {
+    const response = await fetch(`${profile.appApiBaseUrl}/mailbox/me`, {
+      headers: { Authorization: `Bearer ${profile.accessToken}` },
+    });
+    if (response.ok) return;
+    const body = await responseJson(response);
+    if (response.status !== 503 || body.error !== "temporarily_unavailable" || Date.now() >= deadline) {
+      throw new Error(agentAuthFailureMessage(response.status, body));
+    }
+    const retryAfter = retryAfterSeconds(response, body);
+    await new Promise((resolve) => setTimeout(resolve, retryAfter * 1_000));
+  }
+}
+
+async function activeAgentProfile(configDir: string, profileName: string): Promise<ActiveAgentCliProfile> {
+  return activeAgentProfileFromConfig(await readCliConfig(configDir), profileName);
+}
+
+function activeAgentProfileFromConfig(config: CliConfig, profileName: string): ActiveAgentCliProfile {
+  const profile = config.profiles[profileName];
+  if (!profile || !isActiveAgentProfile(profile)) {
+    throw new Error(`Sendmux agent profile "${profileName}" is not active.`);
+  }
+  return profile;
+}
+
+async function postJson<T = Record<string, unknown>>(
+  url: string,
+  options: {
+    body: Record<string, unknown>;
+    expectedStatuses: number[];
+    headers?: Record<string, string>;
+  },
+): Promise<T> {
+  const response = await fetch(url, {
+    body: JSON.stringify(options.body),
+    headers: { "Content-Type": "application/json", ...options.headers },
+    method: "POST",
+  });
+  const body = await responseJson(response);
+  if (!options.expectedStatuses.includes(response.status)) {
+    throw new Error(agentAuthFailureMessage(response.status, body));
+  }
+  return body as T;
+}
+
+async function responseJson(response: Response): Promise<Record<string, unknown>> {
+  const body = await response.json().catch(() => null);
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new Error(`Sendmux agent authentication returned HTTP ${response.status} without a JSON object.`);
+  }
+  return body as Record<string, unknown>;
+}
+
+function retryAfterSeconds(response: Response, body: Record<string, unknown>): number {
+  const value = Number(response.headers.get("Retry-After") ?? body.retry_after ?? 10);
+  return Number.isFinite(value) && value >= 0 ? value : 10;
+}
+
+function agentAuthFailureMessage(status: number, body: Record<string, unknown>): string {
+  if (status === 503 && body.error === "authorization_pending") {
+    return "Agent sending is awaiting owner acceptance or approval.";
+  }
+  if (status === 503 && body.error === "temporarily_unavailable") {
+    return "Agent mailbox provisioning did not finish within the allowed time.";
+  }
+  const description = typeof body.error_description === "string" ? body.error_description : null;
+  return description ?? `Sendmux agent authentication failed with HTTP ${status}.`;
+}
+
+function assertRegistrationResponse(value: AgentRegistrationResponse): void {
+  requiredString(value as unknown as Record<string, unknown>, "access_token", "agent registration");
+  requiredString(value as unknown as Record<string, unknown>, "registration_id", "agent registration");
+  if (!value.mailbox || typeof value.mailbox !== "object" || typeof value.mailbox.email !== "string") {
+    throw new Error("Sendmux agent registration did not return a mailbox email.");
+  }
+}
+
+function requiredString(record: Record<string, unknown>, field: string, source: string): string {
+  const value = record[field];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Sendmux ${source} did not return ${field}.`);
+  }
+  return value;
+}

--- a/packages/ts/cli/src/agent-auth.ts
+++ b/packages/ts/cli/src/agent-auth.ts
@@ -10,7 +10,7 @@ import {
   type AgentCliProfile,
   type CliConfig,
   type RegisteringAgentCliProfile,
-  writeCliConfig,
+  updateCliConfig,
 } from "./profiles.js";
 
 const DEFAULT_APP_ORIGIN = "https://app.sendmux.ai";
@@ -50,48 +50,50 @@ export interface SafeAgentRegistrationResult {
 }
 
 export async function registerAgent(input: RegisterAgentInput): Promise<SafeAgentRegistrationResult> {
-  let config = await readCliConfig(input.configDir);
-  const existing = config.profiles[input.profileName];
+  const initialConfig = await readCliConfig(input.configDir);
+  const existing = initialConfig.profiles[input.profileName];
   let activeProfile: ActiveAgentCliProfile;
 
   if (existing && isActiveAgentProfile(existing)) {
-    assertMatchingRegistration(existing, input);
-    activeProfile = existing;
-    if (input.makeDefault || !config.defaultProfile) {
-      config.defaultProfile = input.profileName;
-      await writeCliConfig(input.configDir, config);
-    }
+    activeProfile = await updateCliConfig(input.configDir, (config) => {
+      const current = config.profiles[input.profileName];
+      if (!current || !isActiveAgentProfile(current)) {
+        throw new Error(`Sendmux agent profile "${input.profileName}" is not active.`);
+      }
+      assertMatchingRegistration(current, input);
+      if (input.makeDefault || !config.defaultProfile) config.defaultProfile = input.profileName;
+      return current;
+    });
     await clearAgentRegistrationIntent(input.configDir, input.profileName);
   } else {
     const candidate = registrationIntent({ existing, input });
     const registering = await reserveAgentRegistrationIntent(input.configDir, input.profileName, candidate);
     assertMatchingRegistration(registering, input);
 
-    config = await readCliConfig(input.configDir);
-    const latestExisting = config.profiles[input.profileName];
-    if (latestExisting && isActiveAgentProfile(latestExisting)) {
-      assertMatchingRegistration(latestExisting, input);
-      activeProfile = latestExisting;
-      if (input.makeDefault || !config.defaultProfile) {
-        config.defaultProfile = input.profileName;
-        await writeCliConfig(input.configDir, config);
+    const persisted = await updateCliConfig(input.configDir, (config) => {
+      const current = config.profiles[input.profileName];
+      if (current && isActiveAgentProfile(current)) {
+        assertMatchingRegistration(current, input);
+        if (input.makeDefault || !config.defaultProfile) config.defaultProfile = input.profileName;
+        return { active: current };
       }
-      await clearAgentRegistrationIntent(input.configDir, input.profileName);
-    } else {
-      if (latestExisting) {
-        if (latestExisting.type !== "agent" || latestExisting.state !== "registering") {
+      if (current) {
+        if (current.type !== "agent" || current.state !== "registering") {
           throw new Error(`Sendmux profile "${input.profileName}" already exists and is not an agent profile.`);
         }
-        if (latestExisting.idempotencyKey !== registering.idempotencyKey) {
+        if (current.idempotencyKey !== registering.idempotencyKey) {
           throw new Error(`Sendmux agent profile "${input.profileName}" belongs to a different registration request.`);
         }
       }
       config.profiles[input.profileName] = registering;
-      if (input.makeDefault || !config.defaultProfile) {
-        config.defaultProfile = input.profileName;
-      }
-      await writeCliConfig(input.configDir, config);
+      if (input.makeDefault || !config.defaultProfile) config.defaultProfile = input.profileName;
+      return { active: null };
+    });
 
+    if (persisted.active) {
+      activeProfile = persisted.active;
+      await clearAgentRegistrationIntent(input.configDir, input.profileName);
+    } else {
       const registration = await postJson<AgentRegistrationResponse>(`${registering.authBaseUrl}/agent/identity`, {
         headers: { "Idempotency-Key": registering.idempotencyKey },
         body: {
@@ -104,16 +106,32 @@ export async function registerAgent(input: RegisterAgentInput): Promise<SafeAgen
       });
       assertRegistrationResponse(registration);
 
-      const afterRegistration = await readCliConfig(input.configDir);
-      activeProfile = {
-        ...registering,
-        accessToken: registration.access_token,
-        mailboxEmail: registration.mailbox.email,
-        registrationId: registration.registration_id,
-        state: "active",
-      };
-      afterRegistration.profiles[input.profileName] = activeProfile;
-      await writeCliConfig(input.configDir, afterRegistration);
+      activeProfile = await updateCliConfig(input.configDir, (config) => {
+        const current = config.profiles[input.profileName];
+        if (current && isActiveAgentProfile(current)) {
+          if (current.idempotencyKey !== registering.idempotencyKey) {
+            throw new Error(`Sendmux agent profile "${input.profileName}" belongs to a different registration request.`);
+          }
+          return current;
+        }
+        if (
+          !current ||
+          current.type !== "agent" ||
+          current.state !== "registering" ||
+          current.idempotencyKey !== registering.idempotencyKey
+        ) {
+          throw new Error(`Sendmux agent profile "${input.profileName}" belongs to a different registration request.`);
+        }
+        const activated: ActiveAgentCliProfile = {
+          ...current,
+          accessToken: registration.access_token,
+          mailboxEmail: registration.mailbox.email,
+          registrationId: registration.registration_id,
+          state: "active",
+        };
+        config.profiles[input.profileName] = activated;
+        return activated;
+      });
       await clearAgentRegistrationIntent(input.configDir, input.profileName);
     }
   }
@@ -147,35 +165,37 @@ export async function inviteAgentOwner({
   email: string;
   profileName: string;
 }): Promise<{ email: string; status: "pending" }> {
-  const config = await readCliConfig(configDir);
-  const profile = activeAgentProfileFromConfig(config, profileName);
-  const existingInvite = profile.ownerInvite;
-  const idempotencyKey =
-    existingInvite?.email.toLowerCase() === email.toLowerCase() ? existingInvite.idempotencyKey : randomUUID();
+  const invitation = await updateCliConfig(configDir, (config) => {
+    const profile = activeAgentProfileFromConfig(config, profileName);
+    const existingInvite = profile.ownerInvite;
+    const idempotencyKey =
+      existingInvite?.email.toLowerCase() === email.toLowerCase() ? existingInvite.idempotencyKey : randomUUID();
+    const updatedProfile: ActiveAgentCliProfile = {
+      ...profile,
+      ownerInvite: { email, idempotencyKey, status: "dispatching" },
+    };
+    config.profiles[profileName] = updatedProfile;
+    return { idempotencyKey, profile: updatedProfile };
+  });
 
-  config.profiles[profileName] = {
-    ...profile,
-    ownerInvite: { email, idempotencyKey, status: "dispatching" as const },
-  };
-  await writeCliConfig(configDir, config);
-
-  const reloaded = await activeAgentProfile(configDir, profileName);
-  await postJson(`${reloaded.authBaseUrl}/agent/identity/invite`, {
+  await postJson(`${invitation.profile.authBaseUrl}/agent/identity/invite`, {
     headers: {
-      Authorization: `Bearer ${reloaded.accessToken}`,
-      "Idempotency-Key": idempotencyKey,
+      Authorization: `Bearer ${invitation.profile.accessToken}`,
+      "Idempotency-Key": invitation.idempotencyKey,
     },
-    body: { email, idempotency_key: idempotencyKey, requested_role: "owner" },
+    body: { email, idempotency_key: invitation.idempotencyKey, requested_role: "owner" },
     expectedStatuses: [200, 202],
   });
 
-  const afterInvite = await readCliConfig(configDir);
-  const current = activeAgentProfileFromConfig(afterInvite, profileName);
-  afterInvite.profiles[profileName] = {
-    ...current,
-    ownerInvite: { email, idempotencyKey, status: "pending" as const },
-  };
-  await writeCliConfig(configDir, afterInvite);
+  await updateCliConfig(configDir, (config) => {
+    const current = activeAgentProfileFromConfig(config, profileName);
+    if (current.ownerInvite?.idempotencyKey === invitation.idempotencyKey) {
+      config.profiles[profileName] = {
+        ...current,
+        ownerInvite: { email, idempotencyKey: invitation.idempotencyKey, status: "pending" as const },
+      };
+    }
+  });
   return { email, status: "pending" };
 }
 
@@ -215,18 +235,23 @@ export async function resolveAgentSendingToken({
     throw new Error("Sendmux token exchange returned an invalid expiry.");
   }
 
-  const latestConfig = await readCliConfig(configDir);
-  const latestProfile = activeAgentProfileFromConfig(latestConfig, profileName);
-  latestConfig.profiles[profileName] = {
-    ...latestProfile,
-    sendingToken: {
-      accessToken,
-      expiresAt: new Date(Date.now() + expiresIn * 1_000).toISOString(),
-    },
-  };
-  await writeCliConfig(configDir, latestConfig);
-  config.profiles[profileName] = latestConfig.profiles[profileName];
-  return accessToken;
+  const updatedProfile = await updateCliConfig(configDir, (latestConfig) => {
+    const latestProfile = activeAgentProfileFromConfig(latestConfig, profileName);
+    if (latestProfile.sendingToken && Date.parse(latestProfile.sendingToken.expiresAt) > Date.now() + SENDING_TOKEN_SKEW_MS) {
+      return latestProfile;
+    }
+    const updated: ActiveAgentCliProfile = {
+      ...latestProfile,
+      sendingToken: {
+        accessToken,
+        expiresAt: new Date(Date.now() + expiresIn * 1_000).toISOString(),
+      },
+    };
+    latestConfig.profiles[profileName] = updated;
+    return updated;
+  });
+  config.profiles[profileName] = updatedProfile;
+  return updatedProfile.sendingToken!.accessToken;
 }
 
 function registrationIntent({

--- a/packages/ts/cli/src/base-command.ts
+++ b/packages/ts/cli/src/base-command.ts
@@ -7,7 +7,12 @@ import {
   type ApiKeyKind,
   type RequiredApiKeyKind,
 } from "./key-kind.js";
-import { readCliConfig } from "./profiles.js";
+import { resolveAgentSendingToken } from "./agent-auth.js";
+import {
+  isActiveAgentProfile,
+  isAgentProfile,
+  readCliConfig,
+} from "./profiles.js";
 
 export interface AuthFlags {
   "api-key"?: string;
@@ -42,8 +47,9 @@ export abstract class SendmuxCommand extends Command {
   static enableJsonFlag = true;
 
   async resolveAuth(flags: AuthFlags, expectedKind: RequiredApiKeyKind): Promise<ResolvedAuth> {
-    const envApiKey = process.env.SENDMUX_API_KEY;
-    const envBaseUrl = process.env.SENDMUX_BASE_URL;
+    const envApiKey = process.env.SENDMUX_API_KEY || undefined;
+    const envBaseUrl = process.env.SENDMUX_BASE_URL || undefined;
+    const envProfile = process.env.SENDMUX_PROFILE || undefined;
 
     if (flags["api-key"] || envApiKey) {
       const apiKey = flags["api-key"] ?? envApiKey;
@@ -65,7 +71,7 @@ export abstract class SendmuxCommand extends Command {
     }
 
     const config = await readCliConfig(this.config.configDir);
-    const profileName = flags.profile ?? process.env.SENDMUX_PROFILE ?? config.defaultProfile;
+    const profileName = flags.profile ?? envProfile ?? config.defaultProfile;
     if (!profileName) {
       this.error("No Sendmux profile configured. Run `sendmux profiles:set <name> --api-key <key> --default` or pass --api-key.", {
         exit: 2,
@@ -76,6 +82,35 @@ export abstract class SendmuxCommand extends Command {
     if (!profile) {
       this.error(`Sendmux profile "${profileName}" was not found. Run \`sendmux profiles:list\` to see configured profiles.`, {
         exit: 2,
+      });
+    }
+
+    if (isAgentProfile(profile)) {
+      if (!isActiveAgentProfile(profile)) {
+        this.error(`Sendmux agent profile "${profileName}" has not finished registration. Re-run \`sendmux agent:register ${profileName}\`.`, {
+          exit: 2,
+        });
+      }
+      if (expectedKind === "root") {
+        this.error(`Command requires a root API key, but profile "${profileName}" is an agent profile.`, { exit: 2 });
+      }
+
+      const apiKey =
+        expectedKind === "sending"
+          ? await resolveAgentSendingToken({
+              config,
+              configDir: this.config.configDir,
+              profile,
+              profileName,
+            })
+          : profile.accessToken;
+      const profileBaseUrl = expectedKind === "sending" ? profile.sendingApiBaseUrl : profile.appApiBaseUrl;
+      const baseUrl = flags["base-url"] ?? envBaseUrl ?? profileBaseUrl;
+      return this.assertKeyKind({
+        apiKey,
+        baseUrl,
+        expectedKind,
+        source: `agent profile "${profileName}"`,
       });
     }
 

--- a/packages/ts/cli/src/commands/agent/invite-owner.ts
+++ b/packages/ts/cli/src/commands/agent/invite-owner.ts
@@ -1,0 +1,40 @@
+import { Args, Flags } from "@oclif/core";
+
+import { inviteAgentOwner } from "../../agent-auth.js";
+import { SendmuxCommand } from "../../base-command.js";
+
+export default class AgentInviteOwner extends SendmuxCommand {
+  static args = {
+    email: Args.string({
+      description: "Owner email address.",
+      required: true,
+    }),
+  };
+  static description = "Invite an owner to approve sending for an agent inbox.";
+  static flags = {
+    profile: Flags.string({
+      char: "p",
+      description: "Registered agent profile name.",
+      required: true,
+    }),
+  };
+
+  async run(): Promise<unknown> {
+    const { args, flags } = await this.parse(AgentInviteOwner);
+    const result = await inviteAgentOwner({
+      configDir: this.config.configDir,
+      email: args.email,
+      profileName: flags.profile,
+    });
+
+    return this.renderResult({
+      ok: true,
+      data: {
+        email: result.email,
+        profile: flags.profile,
+        status: result.status,
+      },
+      meta: {},
+    });
+  }
+}

--- a/packages/ts/cli/src/commands/agent/register.ts
+++ b/packages/ts/cli/src/commands/agent/register.ts
@@ -1,0 +1,46 @@
+import { Args, Flags } from "@oclif/core";
+
+import { registerAgent } from "../../agent-auth.js";
+import { SendmuxCommand } from "../../base-command.js";
+
+export default class AgentRegister extends SendmuxCommand {
+  static args = {
+    profile: Args.string({
+      description: "Local profile name for the agent inbox.",
+      required: true,
+    }),
+  };
+  static description = "Register a durable agent inbox profile.";
+  static flags = {
+    "base-url": Flags.string({
+      description: "Sendmux app origin. Defaults to https://app.sendmux.ai.",
+    }),
+    "client-name": Flags.string({
+      description: "Optional agent client name.",
+    }),
+    default: Flags.boolean({
+      description: "Make this the default profile.",
+    }),
+    "mailbox-local-part": Flags.string({
+      description: "Optional requested mailbox local part.",
+    }),
+    "owner-email": Flags.string({
+      description: "Invite this owner after the inbox becomes ready.",
+    }),
+  };
+
+  async run(): Promise<unknown> {
+    const { args, flags } = await this.parse(AgentRegister);
+    const result = await registerAgent({
+      ...(flags["base-url"] ? { appOrigin: flags["base-url"] } : {}),
+      ...(flags["client-name"] ? { clientName: flags["client-name"] } : {}),
+      configDir: this.config.configDir,
+      makeDefault: flags.default,
+      ...(flags["mailbox-local-part"] ? { mailboxLocalPart: flags["mailbox-local-part"] } : {}),
+      ...(flags["owner-email"] ? { ownerEmail: flags["owner-email"] } : {}),
+      profileName: args.profile,
+    });
+
+    return this.renderResult({ ok: true, data: result, meta: {} });
+  }
+}

--- a/packages/ts/cli/src/commands/profiles/list.ts
+++ b/packages/ts/cli/src/commands/profiles/list.ts
@@ -5,7 +5,11 @@ import {
   inferApiKeyKind,
   maskApiKey,
 } from "../../key-kind.js";
-import { readCliConfig } from "../../profiles.js";
+import {
+  isActiveAgentProfile,
+  isApiKeyProfile,
+  readCliConfig,
+} from "../../profiles.js";
 
 export default class ProfilesList extends SendmuxCommand {
   static description = "List local Sendmux CLI profiles.";
@@ -18,13 +22,32 @@ export default class ProfilesList extends SendmuxCommand {
   async run(): Promise<unknown> {
     const { flags } = await this.parse(ProfilesList);
     const config = await readCliConfig(this.config.configDir);
-    const profiles = Object.entries(config.profiles).map(([name, profile]) => ({
-      default: name === config.defaultProfile,
-      key_kind: inferApiKeyKind(profile.apiKey),
-      name,
-      ...(profile.baseUrl ? { base_url: profile.baseUrl } : {}),
-      ...(flags.verbose ? { api_key: maskApiKey(profile.apiKey) } : {}),
-    }));
+    const profiles = Object.entries(config.profiles).map(([name, profile]) => {
+      if (isApiKeyProfile(profile)) {
+        return {
+          default: name === config.defaultProfile,
+          key_kind: inferApiKeyKind(profile.apiKey),
+          name,
+          ...(profile.baseUrl ? { base_url: profile.baseUrl } : {}),
+          ...(flags.verbose ? { api_key: maskApiKey(profile.apiKey) } : {}),
+          type: "api_key",
+        };
+      }
+
+      return {
+        default: name === config.defaultProfile,
+        ...(isActiveAgentProfile(profile)
+          ? {
+              mailbox_email: profile.mailboxEmail,
+              owner_invite_status: profile.ownerInvite?.status,
+              registration_id: profile.registrationId,
+            }
+          : {}),
+        name,
+        status: profile.state,
+        type: "agent",
+      };
+    });
 
     return this.renderResult({
       ok: true,

--- a/packages/ts/cli/src/commands/profiles/set.ts
+++ b/packages/ts/cli/src/commands/profiles/set.ts
@@ -2,10 +2,7 @@ import { Args, Flags } from "@oclif/core";
 
 import { SendmuxCommand } from "../../base-command.js";
 import { inferApiKeyKind } from "../../key-kind.js";
-import {
-  readCliConfig,
-  writeCliConfig,
-} from "../../profiles.js";
+import { updateCliConfig } from "../../profiles.js";
 
 export default class ProfilesSet extends SendmuxCommand {
   static args = {
@@ -36,23 +33,20 @@ export default class ProfilesSet extends SendmuxCommand {
     }
 
     const keyKind = inferApiKeyKind(apiKey);
-    const config = await readCliConfig(this.config.configDir);
-    config.profiles[args.name] = {
-      apiKey,
-      ...(flags["base-url"] ? { baseUrl: flags["base-url"] } : {}),
-      type: "api_key",
-    };
-
-    if (flags.default || !config.defaultProfile) {
-      config.defaultProfile = args.name;
-    }
-
-    await writeCliConfig(this.config.configDir, config);
+    const isDefault = await updateCliConfig(this.config.configDir, (config) => {
+      config.profiles[args.name] = {
+        apiKey,
+        ...(flags["base-url"] ? { baseUrl: flags["base-url"] } : {}),
+        type: "api_key",
+      };
+      if (flags.default || !config.defaultProfile) config.defaultProfile = args.name;
+      return config.defaultProfile === args.name;
+    });
 
     const result = {
       ok: true,
       data: {
-        default: config.defaultProfile === args.name,
+        default: isDefault,
         key_kind: keyKind,
         name: args.name,
         ...(flags["base-url"] ? { base_url: flags["base-url"] } : {}),

--- a/packages/ts/cli/src/commands/profiles/set.ts
+++ b/packages/ts/cli/src/commands/profiles/set.ts
@@ -40,6 +40,7 @@ export default class ProfilesSet extends SendmuxCommand {
     config.profiles[args.name] = {
       apiKey,
       ...(flags["base-url"] ? { baseUrl: flags["base-url"] } : {}),
+      type: "api_key",
     };
 
     if (flags.default || !config.defaultProfile) {

--- a/packages/ts/cli/src/commands/profiles/show.ts
+++ b/packages/ts/cli/src/commands/profiles/show.ts
@@ -5,7 +5,11 @@ import {
   inferApiKeyKind,
   maskApiKey,
 } from "../../key-kind.js";
-import { readCliConfig } from "../../profiles.js";
+import {
+  isActiveAgentProfile,
+  isApiKeyProfile,
+  readCliConfig,
+} from "../../profiles.js";
 
 export default class ProfilesShow extends SendmuxCommand {
   static args = {
@@ -29,16 +33,29 @@ export default class ProfilesShow extends SendmuxCommand {
       this.error(`Sendmux profile "${profileName}" was not found.`, { exit: 2 });
     }
 
-    return this.renderResult({
-      ok: true,
-      data: {
-        api_key: maskApiKey(profile.apiKey),
-        default: profileName === config.defaultProfile,
-        key_kind: inferApiKeyKind(profile.apiKey),
-        name: profileName,
-        ...(profile.baseUrl ? { base_url: profile.baseUrl } : {}),
-      },
-      meta: {},
-    });
+    const data = isApiKeyProfile(profile)
+      ? {
+          api_key: maskApiKey(profile.apiKey),
+          default: profileName === config.defaultProfile,
+          key_kind: inferApiKeyKind(profile.apiKey),
+          name: profileName,
+          ...(profile.baseUrl ? { base_url: profile.baseUrl } : {}),
+          type: "api_key",
+        }
+      : {
+          default: profileName === config.defaultProfile,
+          ...(isActiveAgentProfile(profile)
+            ? {
+                mailbox_email: profile.mailboxEmail,
+                owner_invite_status: profile.ownerInvite?.status,
+                registration_id: profile.registrationId,
+              }
+            : {}),
+          name: profileName,
+          status: profile.state,
+          type: "agent",
+        };
+
+    return this.renderResult({ ok: true, data, meta: {} });
   }
 }

--- a/packages/ts/cli/src/index.ts
+++ b/packages/ts/cli/src/index.ts
@@ -1,4 +1,8 @@
 export type {
+  ActiveAgentCliProfile,
+  AgentCliProfile,
+  ApiKeyCliProfile,
   CliConfig,
   CliProfile,
+  RegisteringAgentCliProfile,
 } from "./profiles.js";

--- a/packages/ts/cli/src/profiles.ts
+++ b/packages/ts/cli/src/profiles.ts
@@ -79,16 +79,17 @@ export async function readCliConfig(configDir: string): Promise<CliConfig> {
   }
 }
 
-export async function writeCliConfig(configDir: string, config: CliConfig): Promise<void> {
+export async function updateCliConfig<T>(
+  configDir: string,
+  update: (config: CliConfig) => T,
+): Promise<T> {
   await mkdir(configDir, { mode: 0o700, recursive: true });
   const releaseLock = await acquireConfigWriteLock(configDir);
   try {
-    const path = configPath(configDir);
-    const tempPath = `${path}.${process.pid}.tmp`;
-    await writeFile(tempPath, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
-    await chmod(tempPath, 0o600);
-    await rename(tempPath, path);
-    await chmod(path, 0o600);
+    const config = await readCliConfig(configDir);
+    const result = update(config);
+    await writeCliConfigFile(configDir, config);
+    return result;
   } finally {
     await releaseLock();
   }
@@ -101,26 +102,39 @@ export async function reserveAgentRegistrationIntent(
 ): Promise<RegisteringAgentCliProfile> {
   await mkdir(configDir, { mode: 0o700, recursive: true });
   const path = registrationIntentPath(configDir, profileName);
+  const releaseLock = await acquireFileLock(
+    `${path}.lock`,
+    "Timed out waiting for another Sendmux process to reserve the agent registration.",
+  );
 
-  while (true) {
-    try {
-      await writeFile(path, `${JSON.stringify(candidate, null, 2)}\n`, { flag: "wx", mode: 0o600 });
-      await chmod(path, 0o600);
-      return candidate;
-    } catch (error) {
-      if (!isNodeError(error) || error.code !== "EEXIST") throw error;
-    }
-
-    try {
-      const existing = JSON.parse(await readFile(path, "utf8")) as unknown;
-      if (!isRegisteringAgentProfile(existing)) {
-        throw new Error(`Sendmux agent profile "${profileName}" has an invalid registration intent.`);
+  try {
+    while (true) {
+      try {
+        const existing = JSON.parse(await readFile(path, "utf8")) as unknown;
+        if (isRegisteringAgentProfile(existing)) {
+          return existing;
+        }
+        await unlink(path);
+      } catch (error) {
+        if (error instanceof SyntaxError) {
+          await unlink(path).catch((unlinkError: unknown) => {
+            if (!isNodeError(unlinkError) || unlinkError.code !== "ENOENT") throw unlinkError;
+          });
+        } else if (!isNodeError(error) || error.code !== "ENOENT") {
+          throw error;
+        }
       }
-      return existing;
-    } catch (error) {
-      if (isNodeError(error) && error.code === "ENOENT") continue;
-      throw error;
+
+      try {
+        await writeFile(path, `${JSON.stringify(candidate, null, 2)}\n`, { flag: "wx", mode: 0o600 });
+        await chmod(path, 0o600);
+        return candidate;
+      } catch (error) {
+        if (!isNodeError(error) || error.code !== "EEXIST") throw error;
+      }
     }
+  } finally {
+    await releaseLock();
   }
 }
 
@@ -136,8 +150,23 @@ export function configPath(configDir: string): string {
   return join(configDir, CONFIG_FILE);
 }
 
+async function writeCliConfigFile(configDir: string, config: CliConfig): Promise<void> {
+  const path = configPath(configDir);
+  const tempPath = `${path}.${process.pid}.tmp`;
+  await writeFile(tempPath, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
+  await chmod(tempPath, 0o600);
+  await rename(tempPath, path);
+  await chmod(path, 0o600);
+}
+
 async function acquireConfigWriteLock(configDir: string): Promise<() => Promise<void>> {
-  const lockPath = `${configPath(configDir)}.lock`;
+  return acquireFileLock(
+    `${configPath(configDir)}.lock`,
+    "Timed out waiting for another Sendmux process to finish updating the profile config.",
+  );
+}
+
+async function acquireFileLock(lockPath: string, timeoutMessage: string): Promise<() => Promise<void>> {
   const deadline = Date.now() + CONFIG_LOCK_TIMEOUT_MS;
 
   while (true) {
@@ -175,7 +204,7 @@ async function acquireConfigWriteLock(configDir: string): Promise<() => Promise<
     }
 
     if (Date.now() >= deadline) {
-      throw new Error("Timed out waiting for another Sendmux process to finish updating the profile config.");
+      throw new Error(timeoutMessage);
     }
     await new Promise((resolve) => setTimeout(resolve, CONFIG_LOCK_RETRY_MS));
   }

--- a/packages/ts/cli/src/profiles.ts
+++ b/packages/ts/cli/src/profiles.ts
@@ -3,8 +3,10 @@ import {
   mkdir,
   readFile,
   rename,
+  unlink,
   writeFile,
 } from "node:fs/promises";
+import { createHash } from "node:crypto";
 import { join } from "node:path";
 
 export interface ApiKeyCliProfile {
@@ -82,8 +84,66 @@ export async function writeCliConfig(configDir: string, config: CliConfig): Prom
   await chmod(path, 0o600);
 }
 
+export async function reserveAgentRegistrationIntent(
+  configDir: string,
+  profileName: string,
+  candidate: RegisteringAgentCliProfile,
+): Promise<RegisteringAgentCliProfile> {
+  await mkdir(configDir, { mode: 0o700, recursive: true });
+  const path = registrationIntentPath(configDir, profileName);
+
+  while (true) {
+    try {
+      await writeFile(path, `${JSON.stringify(candidate, null, 2)}\n`, { flag: "wx", mode: 0o600 });
+      await chmod(path, 0o600);
+      return candidate;
+    } catch (error) {
+      if (!isNodeError(error) || error.code !== "EEXIST") throw error;
+    }
+
+    try {
+      const existing = JSON.parse(await readFile(path, "utf8")) as unknown;
+      if (!isRegisteringAgentProfile(existing)) {
+        throw new Error(`Sendmux agent profile "${profileName}" has an invalid registration intent.`);
+      }
+      return existing;
+    } catch (error) {
+      if (isNodeError(error) && error.code === "ENOENT") continue;
+      throw error;
+    }
+  }
+}
+
+export async function clearAgentRegistrationIntent(configDir: string, profileName: string): Promise<void> {
+  try {
+    await unlink(registrationIntentPath(configDir, profileName));
+  } catch (error) {
+    if (!isNodeError(error) || error.code !== "ENOENT") throw error;
+  }
+}
+
 export function configPath(configDir: string): string {
   return join(configDir, CONFIG_FILE);
+}
+
+function registrationIntentPath(configDir: string, profileName: string): string {
+  const profileHash = createHash("sha256").update(profileName, "utf8").digest("hex");
+  return join(configDir, `agent-registration-${profileHash}.json`);
+}
+
+function isRegisteringAgentProfile(value: unknown): value is RegisteringAgentCliProfile {
+  if (!value || typeof value !== "object") return false;
+  const profile = value as Partial<RegisteringAgentCliProfile>;
+  return (
+    profile.type === "agent" &&
+    profile.state === "registering" &&
+    typeof profile.appApiBaseUrl === "string" &&
+    typeof profile.authBaseUrl === "string" &&
+    typeof profile.idempotencyKey === "string" &&
+    typeof profile.sendingApiBaseUrl === "string" &&
+    (profile.clientName === undefined || typeof profile.clientName === "string") &&
+    (profile.mailboxLocalPart === undefined || typeof profile.mailboxLocalPart === "string")
+  );
 }
 
 export function isAgentProfile(profile: CliProfile): profile is AgentCliProfile {

--- a/packages/ts/cli/src/profiles.ts
+++ b/packages/ts/cli/src/profiles.ts
@@ -1,8 +1,10 @@
 import {
   chmod,
   mkdir,
+  open,
   readFile,
   rename,
+  stat,
   unlink,
   writeFile,
 } from "node:fs/promises";
@@ -54,6 +56,9 @@ export interface CliConfig {
 }
 
 const CONFIG_FILE = "config.json";
+const CONFIG_LOCK_RETRY_MS = 25;
+const CONFIG_LOCK_STALE_MS = 5_000;
+const CONFIG_LOCK_TIMEOUT_MS = 10_000;
 
 export async function readCliConfig(configDir: string): Promise<CliConfig> {
   const path = configPath(configDir);
@@ -76,12 +81,17 @@ export async function readCliConfig(configDir: string): Promise<CliConfig> {
 
 export async function writeCliConfig(configDir: string, config: CliConfig): Promise<void> {
   await mkdir(configDir, { mode: 0o700, recursive: true });
-  const path = configPath(configDir);
-  const tempPath = `${path}.${process.pid}.tmp`;
-  await writeFile(tempPath, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
-  await chmod(tempPath, 0o600);
-  await rename(tempPath, path);
-  await chmod(path, 0o600);
+  const releaseLock = await acquireConfigWriteLock(configDir);
+  try {
+    const path = configPath(configDir);
+    const tempPath = `${path}.${process.pid}.tmp`;
+    await writeFile(tempPath, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
+    await chmod(tempPath, 0o600);
+    await rename(tempPath, path);
+    await chmod(path, 0o600);
+  } finally {
+    await releaseLock();
+  }
 }
 
 export async function reserveAgentRegistrationIntent(
@@ -124,6 +134,51 @@ export async function clearAgentRegistrationIntent(configDir: string, profileNam
 
 export function configPath(configDir: string): string {
   return join(configDir, CONFIG_FILE);
+}
+
+async function acquireConfigWriteLock(configDir: string): Promise<() => Promise<void>> {
+  const lockPath = `${configPath(configDir)}.lock`;
+  const deadline = Date.now() + CONFIG_LOCK_TIMEOUT_MS;
+
+  while (true) {
+    try {
+      const handle = await open(lockPath, "wx", 0o600);
+      return async () => {
+        try {
+          await handle.close();
+        } finally {
+          try {
+            await unlink(lockPath);
+          } catch (error) {
+            if (!isNodeError(error) || error.code !== "ENOENT") throw error;
+          }
+        }
+      };
+    } catch (error) {
+      if (!isNodeError(error) || error.code !== "EEXIST") throw error;
+    }
+
+    try {
+      const lock = await stat(lockPath);
+      if (Date.now() - lock.mtimeMs >= CONFIG_LOCK_STALE_MS) {
+        try {
+          await unlink(lockPath);
+          continue;
+        } catch (error) {
+          if (isNodeError(error) && error.code === "ENOENT") continue;
+          if (!isNodeError(error) || (error.code !== "EACCES" && error.code !== "EPERM")) throw error;
+        }
+      }
+    } catch (error) {
+      if (isNodeError(error) && error.code === "ENOENT") continue;
+      throw error;
+    }
+
+    if (Date.now() >= deadline) {
+      throw new Error("Timed out waiting for another Sendmux process to finish updating the profile config.");
+    }
+    await new Promise((resolve) => setTimeout(resolve, CONFIG_LOCK_RETRY_MS));
+  }
 }
 
 function registrationIntentPath(configDir: string, profileName: string): string {

--- a/packages/ts/cli/src/profiles.ts
+++ b/packages/ts/cli/src/profiles.ts
@@ -7,10 +7,44 @@ import {
 } from "node:fs/promises";
 import { join } from "node:path";
 
-export interface CliProfile {
+export interface ApiKeyCliProfile {
   apiKey: string;
   baseUrl?: string;
+  type?: "api_key";
 }
+
+interface AgentProfileBase {
+  appApiBaseUrl: string;
+  authBaseUrl: string;
+  clientName?: string;
+  idempotencyKey: string;
+  mailboxLocalPart?: string;
+  sendingApiBaseUrl: string;
+  type: "agent";
+}
+
+export interface RegisteringAgentCliProfile extends AgentProfileBase {
+  state: "registering";
+}
+
+export interface ActiveAgentCliProfile extends AgentProfileBase {
+  accessToken: string;
+  mailboxEmail: string;
+  ownerInvite?: {
+    email: string;
+    idempotencyKey: string;
+    status: "dispatching" | "pending";
+  };
+  registrationId: string;
+  sendingToken?: {
+    accessToken: string;
+    expiresAt: string;
+  };
+  state: "active";
+}
+
+export type AgentCliProfile = ActiveAgentCliProfile | RegisteringAgentCliProfile;
+export type CliProfile = AgentCliProfile | ApiKeyCliProfile;
 
 export interface CliConfig {
   defaultProfile?: string;
@@ -50,6 +84,18 @@ export async function writeCliConfig(configDir: string, config: CliConfig): Prom
 
 export function configPath(configDir: string): string {
   return join(configDir, CONFIG_FILE);
+}
+
+export function isAgentProfile(profile: CliProfile): profile is AgentCliProfile {
+  return profile.type === "agent";
+}
+
+export function isApiKeyProfile(profile: CliProfile): profile is ApiKeyCliProfile {
+  return !isAgentProfile(profile);
+}
+
+export function isActiveAgentProfile(profile: CliProfile): profile is ActiveAgentCliProfile {
+  return isAgentProfile(profile) && profile.state === "active";
 }
 
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {

--- a/scripts/check-cli.mjs
+++ b/scripts/check-cli.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
 import { once } from "node:events";
@@ -43,6 +44,7 @@ ensureCliBuilt();
 
 const serverState = {
   readinessAttempts: 0,
+  crossProfileRegistrationRequests: 0,
   registrationIdempotencyKeys: [],
   registrations: 0,
   requests: [],
@@ -96,16 +98,28 @@ const server = createServer(async (request, response) => {
   if (request.method === "POST" && requestUrl === "/agent-auth/agent/identity") {
     serverState.registrations += 1;
     const configPath = join(tempHome, ".config", "sendmux", "config.json");
-    const savedConfig = JSON.parse(readFileSync(configPath, "utf8"));
     const parsed = JSON.parse(body.toString("utf8"));
     const profileName = parsed.mailbox_local_part;
+    if (profileName === "concurrent-alpha" || profileName === "concurrent-bravo") {
+      serverState.crossProfileRegistrationRequests += 1;
+      while (serverState.crossProfileRegistrationRequests < 2) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+    }
+    const savedConfig = JSON.parse(readFileSync(configPath, "utf8"));
     const registeringProfile = savedConfig.profiles[profileName];
     if (registeringProfile?.type !== "agent" || registeringProfile?.state !== "registering") {
       response.writeHead(500);
       response.end(JSON.stringify({ error: "registration state was not saved before network" }));
       return;
     }
-    if (registeringProfile.idempotencyKey !== request.headers["idempotency-key"] || parsed.idempotency_key !== registeringProfile.idempotencyKey) {
+    const requestIdempotencyKey = request.headers["idempotency-key"];
+    if (
+      typeof requestIdempotencyKey !== "string" ||
+      requestIdempotencyKey.length === 0 ||
+      registeringProfile.idempotencyKey !== requestIdempotencyKey ||
+      parsed.idempotency_key !== registeringProfile.idempotencyKey
+    ) {
       response.writeHead(500);
       response.end(JSON.stringify({ error: "saved idempotency key did not match request" }));
       return;
@@ -133,7 +147,10 @@ const server = createServer(async (request, response) => {
 
   if (request.method === "GET" && requestUrl === "/api/v1/mailbox/me") {
     const authorization = request.headers.authorization;
-    if (authorization !== `Bearer ${durableAgentKey}` && authorization !== `Bearer ${durableAgentKey}_concurrent-agent`) {
+    if (
+      authorization !== `Bearer ${durableAgentKey}` &&
+      !authorization?.startsWith(`Bearer ${durableAgentKey}_`)
+    ) {
       response.writeHead(401, { "Content-Type": "application/json" });
       response.end(JSON.stringify({ error: "wrong durable token" }));
       return;
@@ -907,8 +924,66 @@ try {
   const concurrentKeys = serverState.registrationIdempotencyKeys
     .filter(({ profileName }) => profileName === "concurrent-agent")
     .map(({ key }) => key);
-  if (concurrentKeys.length !== 2 || new Set(concurrentKeys).size !== 1) {
+  if (
+    concurrentKeys.length !== 2 ||
+    concurrentKeys.some((key) => typeof key !== "string" || key.length === 0) ||
+    new Set(concurrentKeys).size !== 1
+  ) {
     throw new Error(`concurrent agent:register used different idempotency keys: ${JSON.stringify(concurrentKeys)}`);
+  }
+
+  writeFileSync(staleConfigLockPath, "");
+  const crossProfileNames = ["concurrent-alpha", "concurrent-bravo"];
+  const crossProfileRuns = crossProfileNames.map((profileName) =>
+    runCli([
+      "agent:register",
+      profileName,
+      "--base-url",
+      baseUrl,
+      "--mailbox-local-part",
+      profileName,
+      "--json",
+    ]),
+  );
+  await waitForPaths(
+    crossProfileNames.map((profileName) =>
+      join(agentConfigDir, `agent-registration-${createHash("sha256").update(profileName, "utf8").digest("hex")}.json`),
+    ),
+  );
+  rmSync(staleConfigLockPath);
+  const crossProfileResults = await Promise.all(crossProfileRuns);
+  for (const result of crossProfileResults) {
+    assertCliSuccess(result, "concurrent cross-profile agent:register");
+  }
+  const configAfterCrossProfileRegistration = JSON.parse(readFileSync(agentConfigPath, "utf8"));
+  for (const profileName of crossProfileNames) {
+    if (configAfterCrossProfileRegistration.profiles[profileName]?.state !== "active") {
+      throw new Error(`concurrent agent:register lost profile ${profileName}`);
+    }
+  }
+
+  for (const [recoveredProfileName, invalidIntent] of [
+    ["recovered-malformed-agent", "{\"state\":"],
+    ["recovered-wrong-shape-agent", JSON.stringify({ type: "api_key" })],
+  ]) {
+    const recoveredIntentPath = join(
+      agentConfigDir,
+      `agent-registration-${createHash("sha256").update(recoveredProfileName, "utf8").digest("hex")}.json`,
+    );
+    writeFileSync(recoveredIntentPath, invalidIntent);
+    const recoveredRegistrationResult = await runCli([
+      "agent:register",
+      recoveredProfileName,
+      "--base-url",
+      baseUrl,
+      "--mailbox-local-part",
+      recoveredProfileName,
+      "--json",
+    ]);
+    assertCliSuccess(recoveredRegistrationResult, `agent:register with invalid intent ${recoveredProfileName}`);
+    if (existsSync(recoveredIntentPath)) {
+      throw new Error(`agent:register did not clear the recovered intent ${recoveredProfileName}`);
+    }
   }
 
   const ownerInviteResult = await runCli([
@@ -1061,6 +1136,16 @@ function runCli(args) {
       });
     });
   });
+}
+
+async function waitForPaths(paths) {
+  const deadline = Date.now() + 5_000;
+  while (paths.some((path) => !existsSync(path))) {
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for paths: ${paths.join(", ")}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
 }
 
 function assertDeepEqual(actual, expected, message) {

--- a/scripts/check-cli.mjs
+++ b/scripts/check-cli.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn, spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
 import { once } from "node:events";
 import { join } from "node:path";
@@ -818,6 +818,13 @@ try {
     throw new Error("Idempotency-Key header was not passed through for sending:send");
   }
 
+  const agentConfigDir = join(tempHome, ".config", "sendmux");
+  const agentConfigPath = join(agentConfigDir, "config.json");
+  const staleConfigLockPath = `${agentConfigPath}.lock`;
+  writeFileSync(staleConfigLockPath, "");
+  const staleConfigLockTime = new Date(Date.now() - 60_000);
+  utimesSync(staleConfigLockPath, staleConfigLockTime, staleConfigLockTime);
+
   const durableRegistrationResult = await runCli([
     "agent:register",
     "durable-agent",
@@ -833,6 +840,9 @@ try {
     "--json",
   ]);
   assertCliSuccess(durableRegistrationResult, "agent:register durable profile");
+  if (existsSync(staleConfigLockPath)) {
+    throw new Error("agent:register did not recover a stale profile config lock");
+  }
   if (durableRegistrationResult.stdout.includes(durableAgentKey)) {
     throw new Error("agent:register printed the durable access token");
   }
@@ -846,8 +856,6 @@ try {
     status: "active",
   }, "agent:register returned unexpected safe profile metadata");
 
-  const agentConfigDir = join(tempHome, ".config", "sendmux");
-  const agentConfigPath = join(agentConfigDir, "config.json");
   if (
     process.platform !== "win32" &&
     ((statSync(agentConfigDir).mode & 0o777) !== 0o700 || (statSync(agentConfigPath).mode & 0o777) !== 0o600)

--- a/scripts/check-cli.mjs
+++ b/scripts/check-cli.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn, spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
 import { once } from "node:events";
 import { join } from "node:path";
@@ -15,6 +15,8 @@ const operationRunnerPath = "packages/ts/cli/src/operation-runner.ts";
 const commandsDir = "packages/ts/cli/src/commands";
 const mailboxKey = "smx_mbx_testkey1234567890";
 const agentKey = "smx_agent_testkey1234567890";
+const durableAgentKey = "smx_agent_durable_read_testkey1234567890";
+const delegatedAgentSendKey = "smx_agent_delegated_send_testkey1234567890";
 const rootKey = "smx_root_testkey1234567890";
 const envelope = {
   ok: true,
@@ -39,7 +41,7 @@ const openApiDocument = {
 
 ensureCliBuilt();
 
-const serverState = { requests: [] };
+const serverState = { readinessAttempts: 0, registrations: 0, requests: [], tokenExchanges: 0 };
 const tempHome = mkdtempSync(join(tmpdir(), "sendmux-cli-"));
 const server = createServer(async (request, response) => {
   const chunks = [];
@@ -85,6 +87,82 @@ const server = createServer(async (request, response) => {
   }
 
   const requestUrl = request.url ?? "";
+  if (request.method === "POST" && requestUrl === "/agent-auth/agent/identity") {
+    serverState.registrations += 1;
+    const configPath = join(tempHome, ".config", "sendmux", "config.json");
+    const savedConfig = JSON.parse(readFileSync(configPath, "utf8"));
+    const registeringProfile = savedConfig.profiles["durable-agent"];
+    const parsed = JSON.parse(body.toString("utf8"));
+    if (registeringProfile?.type !== "agent" || registeringProfile?.state !== "registering") {
+      response.writeHead(500);
+      response.end(JSON.stringify({ error: "registration state was not saved before network" }));
+      return;
+    }
+    if (registeringProfile.idempotencyKey !== request.headers["idempotency-key"] || parsed.idempotency_key !== registeringProfile.idempotencyKey) {
+      response.writeHead(500);
+      response.end(JSON.stringify({ error: "saved idempotency key did not match request" }));
+      return;
+    }
+    response.writeHead(201, { "Content-Type": "application/json" });
+    response.end(JSON.stringify({
+      access_token: durableAgentKey,
+      mailbox: { email: "durable-agent@myagent.mx", status: "provisioning" },
+      registration_id: "areg_cli_durable",
+      registration_type: "anonymous",
+      scope: "mailbox.read email.receive",
+      token_type: "Bearer",
+    }));
+    return;
+  }
+
+  if (request.method === "GET" && requestUrl === "/api/v1/mailbox/me") {
+    serverState.readinessAttempts += 1;
+    if (request.headers.authorization !== `Bearer ${durableAgentKey}`) {
+      response.writeHead(401, { "Content-Type": "application/json" });
+      response.end(JSON.stringify({ error: "wrong durable token" }));
+      return;
+    }
+    if (serverState.readinessAttempts === 1) {
+      response.writeHead(503, { "Content-Type": "application/json", "Retry-After": "0" });
+      response.end(JSON.stringify({ error: "temporarily_unavailable", retry_after: 0 }));
+      return;
+    }
+    response.setHeader("Content-Type", "application/json");
+    response.end(JSON.stringify({ ok: true, data: { email: "durable-agent@myagent.mx" }, meta: {} }));
+    return;
+  }
+
+  if (request.method === "POST" && requestUrl === "/agent-auth/agent/identity/invite") {
+    response.writeHead(202, { "Content-Type": "application/json" });
+    response.end(JSON.stringify({ invite_id: "ainv_cli_owner", status: "pending" }));
+    return;
+  }
+
+  if (request.method === "POST" && requestUrl === "/agent-auth/oauth2/token") {
+    serverState.tokenExchanges += 1;
+    const form = new URLSearchParams(body.toString("utf8"));
+    if (
+      form.get("grant_type") !== "urn:ietf:params:oauth:grant-type:token-exchange" ||
+      form.get("subject_token") !== durableAgentKey ||
+      form.get("subject_token_type") !== "urn:ietf:params:oauth:token-type:access_token" ||
+      form.get("resource") !== "https://smtp.sendmux.ai/api/v1" ||
+      form.get("scope") !== "email.send"
+    ) {
+      response.writeHead(400, { "Content-Type": "application/json" });
+      response.end(JSON.stringify({ error: "invalid exchange" }));
+      return;
+    }
+    response.setHeader("Content-Type", "application/json");
+    response.end(JSON.stringify({
+      access_token: delegatedAgentSendKey,
+      expires_in: 3600,
+      issued_token_type: "urn:ietf:params:oauth:token-type:access_token",
+      scope: "email.send",
+      token_type: "Bearer",
+    }));
+    return;
+  }
+
   if (request.method === "POST" && requestUrl.startsWith("/mailbox/attachments:upload")) {
     const url = new URL(requestUrl, "http://127.0.0.1");
     const filename = url.searchParams.get("filename") ?? "attachment.bin";
@@ -718,6 +796,119 @@ try {
 
   if (latestRequest().headers["idempotency-key"] !== "idem_cli_send") {
     throw new Error("Idempotency-Key header was not passed through for sending:send");
+  }
+
+  const durableRegistrationResult = await runCli([
+    "agent:register",
+    "durable-agent",
+    "--base-url",
+    baseUrl,
+    "--client-name",
+    "CLI durable agent",
+    "--mailbox-local-part",
+    "durable-agent",
+    "--owner-email",
+    "owner@example.com",
+    "--default",
+    "--json",
+  ]);
+  assertCliSuccess(durableRegistrationResult, "agent:register durable profile");
+  if (durableRegistrationResult.stdout.includes(durableAgentKey)) {
+    throw new Error("agent:register printed the durable access token");
+  }
+  const durableResultBody = JSON.parse(durableRegistrationResult.stdout);
+  assertDeepEqual(durableResultBody.data, {
+    default: true,
+    mailbox_email: "durable-agent@myagent.mx",
+    name: "durable-agent",
+    owner_invite_status: "pending",
+    registration_id: "areg_cli_durable",
+    status: "active",
+  }, "agent:register returned unexpected safe profile metadata");
+
+  const agentConfigDir = join(tempHome, ".config", "sendmux");
+  const agentConfigPath = join(agentConfigDir, "config.json");
+  if ((statSync(agentConfigDir).mode & 0o777) !== 0o700 || (statSync(agentConfigPath).mode & 0o777) !== 0o600) {
+    throw new Error("agent profile storage permissions are not 0700/0600");
+  }
+  const agentConfig = JSON.parse(readFileSync(agentConfigPath, "utf8"));
+  if (agentConfig.profiles["durable-agent"].accessToken !== durableAgentKey) {
+    throw new Error("agent:register did not persist the durable access token");
+  }
+  if (serverState.readinessAttempts !== 2) {
+    throw new Error(`agent:register did not poll readiness through a temporary 503: ${serverState.readinessAttempts}`);
+  }
+
+  const resumedRegistrationResult = await runCli([
+    "agent:register",
+    "durable-agent",
+    "--base-url",
+    baseUrl,
+    "--client-name",
+    "CLI durable agent",
+    "--mailbox-local-part",
+    "durable-agent",
+    "--default",
+    "--json",
+  ]);
+  assertCliSuccess(resumedRegistrationResult, "agent:register resume from an active persisted profile");
+  if (serverState.registrations !== 1) {
+    throw new Error("agent:register resume created a duplicate registration");
+  }
+
+  const ownerInviteResult = await runCli([
+    "agent:invite-owner",
+    "second-owner@example.com",
+    "--profile",
+    "durable-agent",
+    "--json",
+  ]);
+  assertCliSuccess(ownerInviteResult, "agent:invite-owner with a freshly reloaded durable profile");
+  assertDeepEqual(JSON.parse(ownerInviteResult.stdout).data, {
+    email: "second-owner@example.com",
+    profile: "durable-agent",
+    status: "pending",
+  }, "agent:invite-owner returned unexpected safe metadata");
+  if (latestRequest().headers.authorization !== `Bearer ${durableAgentKey}`) {
+    throw new Error("agent:invite-owner did not use the durable read token");
+  }
+
+  const durableMailboxResult = await runCli(["mailbox:me:get", "--profile", "durable-agent", "--json"]);
+  assertCliSuccess(durableMailboxResult, "mailbox read with a freshly reloaded durable profile");
+  if (latestRequest().headers.authorization !== `Bearer ${durableAgentKey}`) {
+    throw new Error("mailbox operation did not use the durable read token");
+  }
+
+  const exchangedSendResult = await runCli([
+    "sending:send",
+    "--profile",
+    "durable-agent",
+    "--body",
+    "{}",
+    "--idempotency-key",
+    "idem_cli_exchanged_send",
+    "--json",
+  ]);
+  assertCliSuccess(exchangedSendResult, "sending:send with automatic agent token exchange");
+  if (latestRequest().headers.authorization !== `Bearer ${delegatedAgentSendKey}`) {
+    throw new Error("sending operation did not use the delegated send token");
+  }
+  if (serverState.tokenExchanges !== 1) {
+    throw new Error(`sending operation made ${serverState.tokenExchanges} token exchanges instead of one`);
+  }
+
+  const cachedSendResult = await runCli([
+    "sending:send",
+    "--profile",
+    "durable-agent",
+    "--body",
+    "{}",
+    "--idempotency-key",
+    "idem_cli_cached_send",
+  ]);
+  assertCliSuccess(cachedSendResult, "sending:send with cached delegated token");
+  if (serverState.tokenExchanges !== 1) {
+    throw new Error("sending operation did not reuse the unexpired delegated token across processes");
   }
 
   const requestCountBeforeAgentSendingPreflight = serverState.requests.length;

--- a/scripts/check-cli.mjs
+++ b/scripts/check-cli.mjs
@@ -41,7 +41,13 @@ const openApiDocument = {
 
 ensureCliBuilt();
 
-const serverState = { readinessAttempts: 0, registrations: 0, requests: [], tokenExchanges: 0 };
+const serverState = {
+  readinessAttempts: 0,
+  registrationIdempotencyKeys: [],
+  registrations: 0,
+  requests: [],
+  tokenExchanges: 0,
+};
 const tempHome = mkdtempSync(join(tmpdir(), "sendmux-cli-"));
 const server = createServer(async (request, response) => {
   const chunks = [];
@@ -91,8 +97,9 @@ const server = createServer(async (request, response) => {
     serverState.registrations += 1;
     const configPath = join(tempHome, ".config", "sendmux", "config.json");
     const savedConfig = JSON.parse(readFileSync(configPath, "utf8"));
-    const registeringProfile = savedConfig.profiles["durable-agent"];
     const parsed = JSON.parse(body.toString("utf8"));
+    const profileName = parsed.mailbox_local_part;
+    const registeringProfile = savedConfig.profiles[profileName];
     if (registeringProfile?.type !== "agent" || registeringProfile?.state !== "registering") {
       response.writeHead(500);
       response.end(JSON.stringify({ error: "registration state was not saved before network" }));
@@ -103,11 +110,20 @@ const server = createServer(async (request, response) => {
       response.end(JSON.stringify({ error: "saved idempotency key did not match request" }));
       return;
     }
+    serverState.registrationIdempotencyKeys.push({
+      key: request.headers["idempotency-key"],
+      profileName,
+    });
+    if (profileName === "concurrent-agent") {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    const accessToken = profileName === "durable-agent" ? durableAgentKey : `${durableAgentKey}_${profileName}`;
+    const registrationId = profileName === "durable-agent" ? "areg_cli_durable" : `areg_cli_${profileName}`;
     response.writeHead(201, { "Content-Type": "application/json" });
     response.end(JSON.stringify({
-      access_token: durableAgentKey,
-      mailbox: { email: "durable-agent@myagent.mx", status: "provisioning" },
-      registration_id: "areg_cli_durable",
+      access_token: accessToken,
+      mailbox: { email: `${profileName}@myagent.mx`, status: "provisioning" },
+      registration_id: registrationId,
       registration_type: "anonymous",
       scope: "mailbox.read email.receive",
       token_type: "Bearer",
@@ -116,13 +132,16 @@ const server = createServer(async (request, response) => {
   }
 
   if (request.method === "GET" && requestUrl === "/api/v1/mailbox/me") {
-    serverState.readinessAttempts += 1;
-    if (request.headers.authorization !== `Bearer ${durableAgentKey}`) {
+    const authorization = request.headers.authorization;
+    if (authorization !== `Bearer ${durableAgentKey}` && authorization !== `Bearer ${durableAgentKey}_concurrent-agent`) {
       response.writeHead(401, { "Content-Type": "application/json" });
       response.end(JSON.stringify({ error: "wrong durable token" }));
       return;
     }
-    if (serverState.readinessAttempts === 1) {
+    if (authorization === `Bearer ${durableAgentKey}`) {
+      serverState.readinessAttempts += 1;
+    }
+    if (authorization === `Bearer ${durableAgentKey}` && serverState.readinessAttempts === 1) {
       response.writeHead(503, { "Content-Type": "application/json", "Retry-After": "0" });
       response.end(JSON.stringify({ error: "temporarily_unavailable", retry_after: 0 }));
       return;
@@ -258,6 +277,7 @@ try {
   assertCliCommandCoverage();
   assertBinaryOperationRunnerGuard();
   await assertCliArrayParameterSupport();
+  await assertAgentAuthNetworkBoundaries();
 
   const address = server.address();
   if (!address || typeof address === "string") {
@@ -845,18 +865,42 @@ try {
   const resumedRegistrationResult = await runCli([
     "agent:register",
     "durable-agent",
-    "--base-url",
-    baseUrl,
-    "--client-name",
-    "CLI durable agent",
-    "--mailbox-local-part",
-    "durable-agent",
     "--default",
     "--json",
   ]);
   assertCliSuccess(resumedRegistrationResult, "agent:register resume from an active persisted profile");
   if (serverState.registrations !== 1) {
     throw new Error("agent:register resume created a duplicate registration");
+  }
+
+  const concurrentResults = await Promise.all([
+    runCli([
+      "agent:register",
+      "concurrent-agent",
+      "--base-url",
+      baseUrl,
+      "--mailbox-local-part",
+      "concurrent-agent",
+      "--json",
+    ]),
+    runCli([
+      "agent:register",
+      "concurrent-agent",
+      "--base-url",
+      baseUrl,
+      "--mailbox-local-part",
+      "concurrent-agent",
+      "--json",
+    ]),
+  ]);
+  for (const result of concurrentResults) {
+    assertCliSuccess(result, "concurrent agent:register");
+  }
+  const concurrentKeys = serverState.registrationIdempotencyKeys
+    .filter(({ profileName }) => profileName === "concurrent-agent")
+    .map(({ key }) => key);
+  if (concurrentKeys.length !== 2 || new Set(concurrentKeys).size !== 1) {
+    throw new Error(`concurrent agent:register used different idempotency keys: ${JSON.stringify(concurrentKeys)}`);
   }
 
   const ownerInviteResult = await runCli([
@@ -1087,6 +1131,71 @@ function assertBinaryOperationRunnerGuard() {
   if (!branch.includes('throw new Error("SDK operation mailboxGetMessageAttachment did not return binary content");')) {
     throw new Error("CLI attachment branch must reject non-binary data instead of falling through");
   }
+}
+
+async function assertAgentAuthNetworkBoundaries() {
+  const { normaliseAppOrigin, waitForMailbox } = await import("../packages/ts/cli/dist/agent-auth.js");
+
+  for (const origin of ["http://localhost:3000", "http://127.0.0.2:3000", "http://[::1]:3000"]) {
+    if (normaliseAppOrigin(origin) !== new URL(origin).origin) {
+      throw new Error(`agent auth rejected loopback HTTP origin ${origin}`);
+    }
+  }
+  for (const origin of ["http://example.com", "http://127.1", "http://2130706433"]) {
+    try {
+      normaliseAppOrigin(origin);
+      throw new Error(`agent auth accepted non-loopback or non-canonical HTTP origin ${origin}`);
+    } catch (error) {
+      if (String(error).includes("accepted non-loopback")) throw error;
+    }
+  }
+
+  const profile = {
+    accessToken: "smx_agent_timeout",
+    appApiBaseUrl: "https://app.sendmux.ai/api/v1",
+    authBaseUrl: "https://app.sendmux.ai/agent-auth",
+    idempotencyKey: "idem_timeout",
+    mailboxEmail: "timeout@myagent.mx",
+    registrationId: "areg_timeout",
+    sendingApiBaseUrl: "https://smtp.sendmux.ai/api/v1",
+    state: "active",
+    type: "agent",
+  };
+  const originalFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = (_url, options) =>
+      new Promise((_resolve, reject) => {
+        options?.signal?.addEventListener("abort", () => reject(options.signal.reason), { once: true });
+      });
+    const startedAt = Date.now();
+    await expectMailboxTimeout(() => waitForMailbox(profile, 50));
+    if (Date.now() - startedAt > 500) {
+      throw new Error("agent mailbox readiness fetch exceeded its timeout budget");
+    }
+
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ error: "service_unavailable", retry_after: 999_999 }), {
+        headers: { "Content-Type": "application/json", "Retry-After": "999999" },
+        status: 503,
+      });
+    const retryStartedAt = Date.now();
+    await expectMailboxTimeout(() => waitForMailbox(profile, 50));
+    if (Date.now() - retryStartedAt > 500) {
+      throw new Error("agent mailbox Retry-After exceeded the remaining timeout budget");
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+async function expectMailboxTimeout(run) {
+  try {
+    await run();
+  } catch (error) {
+    if (String(error).includes("did not finish within the allowed time")) return;
+    throw error;
+  }
+  throw new Error("agent mailbox readiness unexpectedly completed");
 }
 
 async function assertCliArrayParameterSupport() {

--- a/scripts/check-cli.mjs
+++ b/scripts/check-cli.mjs
@@ -828,7 +828,10 @@ try {
 
   const agentConfigDir = join(tempHome, ".config", "sendmux");
   const agentConfigPath = join(agentConfigDir, "config.json");
-  if ((statSync(agentConfigDir).mode & 0o777) !== 0o700 || (statSync(agentConfigPath).mode & 0o777) !== 0o600) {
+  if (
+    process.platform !== "win32" &&
+    ((statSync(agentConfigDir).mode & 0o777) !== 0o700 || (statSync(agentConfigPath).mode & 0o777) !== 0o600)
+  ) {
     throw new Error("agent profile storage permissions are not 0700/0600");
   }
   const agentConfig = JSON.parse(readFileSync(agentConfigPath, "utf8"));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI support for registering agent inboxes without an existing account or API key.
  * Added `agent register` and `agent invite-owner` commands.
  * Added mailbox-readiness polling and owner-approval workflows.
  * Sending now uses automatically exchanged, temporary delegated credentials with secure caching.
  * Added agent profile status and metadata to `profiles list` and `profiles show`.
  * Existing API-key profiles remain supported.

* **Documentation**
  * Updated quick-start and CLI guidance for agent onboarding, durable credentials, approval, and sending requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds durable agent onboarding to the TypeScript CLI, including persisted agent profiles, owner invitations, mailbox-read authentication, and automatic delegated sending-token exchange and caching.
- Adds `agent:register` and `agent:invite-owner` commands.
- Extends profile persistence and display commands with registering and active agent states.
- Resolves durable credentials for mailbox operations and exchanges short-lived credentials for sending operations.
- Expands CLI integration checks and onboarding documentation.

<h3>Confidence Score: 4/5</h3>

The concurrent same-profile registration race should be fixed before merging because it can create an orphaned durable agent identity.

Registration does not serialize the initial profile-absence check and intent write, so two processes can submit different idempotency keys for the same local profile and retain only one resulting identity.

**Files Needing Attention:** packages/ts/cli/src/agent-auth.ts and packages/ts/cli/src/profiles.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/ts/cli/src/agent-auth.ts | Implements registration, invitations, readiness polling, and sending-token exchange, but same-name concurrent registration can create multiple identities. |
| packages/ts/cli/src/base-command.ts | Extends credential and endpoint resolution to support active agent profiles across mailbox and sending operations. |
| packages/ts/cli/src/profiles.ts | Introduces discriminated agent profile states while retaining backward compatibility for existing API-key profiles. |
| scripts/check-cli.mjs | Adds end-to-end checks for durable registration, private storage, readiness polling, invitations, mailbox access, and delegated-token caching. |
| packages/ts/cli/src/commands/agent/register.ts | Adds the CLI entry point and flags for durable agent registration. |
| packages/ts/cli/src/commands/agent/invite-owner.ts | Adds the CLI command for inviting an owner to an active agent profile. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant CLI as agent:register
  participant Config as Local profile config
  participant Auth as Agent auth service
  participant Mailbox as Mailbox API
  CLI->>Config: Persist registering intent and idempotency key
  CLI->>Auth: Register anonymous identity
  Auth-->>CLI: Durable token and mailbox metadata
  CLI->>Config: Persist active agent profile
  loop Until mailbox is ready
    CLI->>Mailbox: GET /mailbox/me
    Mailbox-->>CLI: Ready or temporary 503
  end
  opt Owner email supplied
    CLI->>Auth: Invite owner
    CLI->>Config: Persist pending invitation
  end
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20sendmux%2Fsendmux-sdk%20PR%20%23155%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=sendmux%2Fsendmux-sdk&pr=155&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fts%2Fcli%2Fsrc%2Fagent-auth.ts%3A56-67%0A**Concurrent%20registration%20orphans%20identities**%0A%0AIf%20two%20processes%20register%20the%20same%20unused%20profile%20concurrently%2C%20both%20can%20observe%20it%20as%20absent%2C%20generate%20different%20idempotency%20keys%2C%20and%20submit%20separate%20registrations%20before%20replacing%20the%20same%20local%20profile%2C%20causing%20one%20durable%20server-side%20identity%20and%20inbox%20to%20become%20orphaned.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=sendmux%2Fsendmux-sdk&pr=155&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(cli): add durable agent onboarding"](https://github.com/sendmux/sendmux-sdk/commit/752c1802877bccf15202d5abb5955496f83242d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58598232)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [TypeScript command-line interface](https://app.greptile.com/jonahnz/-/custom-context/knowledge-base/sendmux/sendmux-sdk/-/docs/typescript-cli.md)

<!-- /greptile_comment -->