### PR TITLE
fix: sync mailbox reliability clients

### DIFF
--- a/go/management/oas_cfg_gen.go
+++ b/go/management/oas_cfg_gen.go
@@ -12,9 +12,13 @@ import (
 	ht "github.com/ogen-go/ogen/http"
 	"github.com/ogen-go/ogen/middleware"
 	"github.com/ogen-go/ogen/ogenerrors"
+	"github.com/ogen-go/ogen/ogenregex"
 	"github.com/ogen-go/ogen/otelogen"
 )
 
+var regexMap = map[string]ogenregex.Regexp{
+	"^(?![^@]*\\.\\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,63}$": ogenregex.MustCompile("^(?![^@]*\\.\\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,63}$"),
+}
 var (
 	// Allocate option closure once.
 	clientSpanKind = trace.WithSpanKind(trace.SpanKindClient)

--- a/go/management/oas_cfg_gen.go
+++ b/go/management/oas_cfg_gen.go
@@ -17,7 +17,7 @@ import (
 )
 
 var regexMap = map[string]ogenregex.Regexp{
-	"^(?![^@]*\\.\\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,63}$": ogenregex.MustCompile("^(?![^@]*\\.\\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,63}$"),
+	"^(?![^\\r\\n]*[\\r\\n])(?![^@]*\\.\\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,63}$": ogenregex.MustCompile("^(?![^\\r\\n]*[\\r\\n])(?![^@]*\\.\\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,63}$"),
 }
 var (
 	// Allocate option closure once.

--- a/go/management/oas_validators_gen.go
+++ b/go/management/oas_validators_gen.go
@@ -2719,7 +2719,7 @@ func (s *ManagementCreateMailboxReq) Validate() error {
 			MaxLengthSet: true,
 			Email:        false,
 			Hostname:     false,
-			Regex:        regexMap["^(?![^@]*\\.\\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,63}$"],
+			Regex:        regexMap["^(?![^\\r\\n]*[\\r\\n])(?![^@]*\\.\\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,63}$"],
 		}).Validate(string(s.Email)); err != nil {
 			return errors.Wrap(err, "string")
 		}

--- a/go/management/oas_validators_gen.go
+++ b/go/management/oas_validators_gen.go
@@ -2719,7 +2719,7 @@ func (s *ManagementCreateMailboxReq) Validate() error {
 			MaxLengthSet: true,
 			Email:        false,
 			Hostname:     false,
-			Regex:        nil,
+			Regex:        regexMap["^(?![^@]*\\.\\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,63}$"],
 		}).Validate(string(s.Email)); err != nil {
 			return errors.Wrap(err, "string")
 		}

--- a/packages/php/management/src/Model/ManagementCreateMailboxRequest.php
+++ b/packages/php/management/src/Model/ManagementCreateMailboxRequest.php
@@ -292,6 +292,10 @@ class ManagementCreateMailboxRequest implements ModelInterface, ArrayAccess, Jso
             $invalidProperties[] = "invalid value for 'email', the character length must be bigger than or equal to 5.";
         }
 
+        if (!preg_match("/^(?![^@]*\\.\\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,63}$/", $this->container['email'])) {
+            $invalidProperties[] = "invalid value for 'email', must be conform to the pattern /^(?![^@]*\\.\\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,63}$/.";
+        }
+
         if (!is_null($this->container['quota_bytes']) && ($this->container['quota_bytes'] < 1)) {
             $invalidProperties[] = "invalid value for 'quota_bytes', must be bigger than or equal to 1.";
         }
@@ -369,6 +373,9 @@ class ManagementCreateMailboxRequest implements ModelInterface, ArrayAccess, Jso
         }
         if ((mb_strlen($email) < 5)) {
             throw new InvalidArgumentException('invalid length for $email when calling ManagementCreateMailboxRequest., must be bigger than or equal to 5.');
+        }
+        if ((!preg_match("/^(?![^@]*\\.\\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,63}$/", ObjectSerializer::toString($email)))) {
+            throw new InvalidArgumentException("invalid value for \$email when calling ManagementCreateMailboxRequest., must conform to the pattern /^(?![^@]*\\.\\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,63}$/.");
         }
 
         $this->container['email'] = $email;

--- a/packages/php/management/src/Model/ManagementCreateMailboxRequest.php
+++ b/packages/php/management/src/Model/ManagementCreateMailboxRequest.php
@@ -292,8 +292,8 @@ class ManagementCreateMailboxRequest implements ModelInterface, ArrayAccess, Jso
             $invalidProperties[] = "invalid value for 'email', the character length must be bigger than or equal to 5.";
         }
 
-        if (!preg_match("/^(?![^@]*\\.\\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,63}$/", $this->container['email'])) {
-            $invalidProperties[] = "invalid value for 'email', must be conform to the pattern /^(?![^@]*\\.\\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,63}$/.";
+        if (!preg_match("/^(?![^\\r\\n]*[\\r\\n])(?![^@]*\\.\\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,63}$/", $this->container['email'])) {
+            $invalidProperties[] = "invalid value for 'email', must be conform to the pattern /^(?![^\\r\\n]*[\\r\\n])(?![^@]*\\.\\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,63}$/.";
         }
 
         if (!is_null($this->container['quota_bytes']) && ($this->container['quota_bytes'] < 1)) {
@@ -374,8 +374,8 @@ class ManagementCreateMailboxRequest implements ModelInterface, ArrayAccess, Jso
         if ((mb_strlen($email) < 5)) {
             throw new InvalidArgumentException('invalid length for $email when calling ManagementCreateMailboxRequest., must be bigger than or equal to 5.');
         }
-        if ((!preg_match("/^(?![^@]*\\.\\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,63}$/", ObjectSerializer::toString($email)))) {
-            throw new InvalidArgumentException("invalid value for \$email when calling ManagementCreateMailboxRequest., must conform to the pattern /^(?![^@]*\\.\\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,63}$/.");
+        if ((!preg_match("/^(?![^\\r\\n]*[\\r\\n])(?![^@]*\\.\\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,63}$/", ObjectSerializer::toString($email)))) {
+            throw new InvalidArgumentException("invalid value for \$email when calling ManagementCreateMailboxRequest., must conform to the pattern /^(?![^\\r\\n]*[\\r\\n])(?![^@]*\\.\\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,63}$/.");
         }
 
         $this->container['email'] = $email;

--- a/packages/php/tests/ManagementValidationTest.php
+++ b/packages/php/tests/ManagementValidationTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sendmux\Tests;
+
+use Sendmux\Management\Model\ManagementCreateMailboxRequest;
+use PHPUnit\Framework\TestCase;
+
+final class ManagementValidationTest extends TestCase
+{
+    public function testMailboxEmailValidationRejectsLineBreaks(): void
+    {
+        foreach (["agent@example.com\n", "agent@example.com\r", "agent@example.com\r\n"] as $email) {
+            $request = new ManagementCreateMailboxRequest(['email' => $email]);
+
+            self::assertFalse($request->valid(), sprintf('Expected %s to be rejected', json_encode($email)));
+        }
+    }
+
+    public function testMailboxEmailValidationAcceptsAValidFullValue(): void
+    {
+        $request = new ManagementCreateMailboxRequest(['email' => 'agent@example.com']);
+
+        self::assertTrue($request->valid());
+        self::assertSame('agent@example.com', $request->getEmail());
+    }
+}

--- a/packages/python/management/sendmux_management/models/management_create_mailbox_request.py
+++ b/packages/python/management/sendmux_management/models/management_create_mailbox_request.py
@@ -17,7 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
 from typing_extensions import Annotated
 from sendmux_management.models.management_create_mailbox_request_send_scope import ManagementCreateMailboxRequestSendScope
@@ -34,6 +34,16 @@ class ManagementCreateMailboxRequest(BaseModel):
     quota_bytes: Optional[Annotated[int, Field(strict=True, ge=1)]] = Field(default=None, description="Storage quota in bytes. Allowed values: 1073741824 (1 GB), 5368709120 (5 GB), 53687091200 (50 GB).")
     send_scope: Optional[ManagementCreateMailboxRequestSendScope] = None
     __properties: ClassVar[List[str]] = ["display_name", "email", "quota_bytes", "send_scope"]
+
+    @field_validator('email')
+    def email_validate_regular_expression(cls, value):
+        """Validates the regular expression"""
+        if not isinstance(value, str):
+            value = str(value)
+
+        if not re.match(r"^(?![^@]*\.\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,63}$", value):
+            raise ValueError(r"must validate the regular expression /^(?![^@]*\.\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,63}$/")
+        return value
 
     model_config = ConfigDict(
         validate_by_name=True,

--- a/packages/python/management/sendmux_management/models/management_create_mailbox_request.py
+++ b/packages/python/management/sendmux_management/models/management_create_mailbox_request.py
@@ -41,8 +41,8 @@ class ManagementCreateMailboxRequest(BaseModel):
         if not isinstance(value, str):
             value = str(value)
 
-        if not re.match(r"^(?![^@]*\.\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,63}$", value):
-            raise ValueError(r"must validate the regular expression /^(?![^@]*\.\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,63}$/")
+        if not re.match(r"^(?![^\r\n]*[\r\n])(?![^@]*\.\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,63}$", value):
+            raise ValueError(r"must validate the regular expression /^(?![^\r\n]*[\r\n])(?![^@]*\.\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,63}$/")
         return value
 
     model_config = ConfigDict(

--- a/packages/python/mcp/sendmux_mcp/openapi/openapi-app.json
+++ b/packages/python/mcp/sendmux_mcp/openapi/openapi-app.json
@@ -14150,6 +14150,7 @@
                     "description": "Mailbox email address to create.",
                     "maxLength": 254,
                     "minLength": 5,
+                    "pattern": "^(?![^@]*\\.\\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,63}$",
                     "type": "string"
                   },
                   "quota_bytes": {

--- a/packages/python/mcp/sendmux_mcp/openapi/openapi-app.json
+++ b/packages/python/mcp/sendmux_mcp/openapi/openapi-app.json
@@ -14150,7 +14150,7 @@
                     "description": "Mailbox email address to create.",
                     "maxLength": 254,
                     "minLength": 5,
-                    "pattern": "^(?![^@]*\\.\\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,63}$",
+                    "pattern": "^(?![^\\r\\n]*[\\r\\n])(?![^@]*\\.\\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,63}$",
                     "type": "string"
                   },
                   "quota_bytes": {

--- a/packages/python/tests/test_management_validation.py
+++ b/packages/python/tests/test_management_validation.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from sendmux_management import ManagementCreateMailboxRequest
+
+
+@pytest.mark.parametrize("email", ["agent@example.com\n", "agent@example.com\r", "agent@example.com\r\n"])
+def test_management_mailbox_email_rejects_line_breaks(email: str) -> None:
+    with pytest.raises(ValidationError):
+        ManagementCreateMailboxRequest(email=email)
+
+
+def test_management_mailbox_email_accepts_a_valid_full_value() -> None:
+    request = ManagementCreateMailboxRequest(email="agent@example.com")
+
+    assert request.email == "agent@example.com"

--- a/packages/ruby/management/lib/sendmux_management_generated/models/management_create_mailbox_request.rb
+++ b/packages/ruby/management/lib/sendmux_management_generated/models/management_create_mailbox_request.rb
@@ -122,6 +122,11 @@ module Sendmux::Management::Generated
         invalid_properties.push('invalid value for "email", the character length must be greater than or equal to 5.')
       end
 
+      pattern = Regexp.new(/^(?![^@]*\.\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,63}$/)
+      if @email !~ pattern
+        invalid_properties.push("invalid value for \"email\", must conform to the pattern #{pattern}.")
+      end
+
       if !@quota_bytes.nil? && @quota_bytes < 1
         invalid_properties.push('invalid value for "quota_bytes", must be greater than or equal to 1.')
       end
@@ -138,6 +143,7 @@ module Sendmux::Management::Generated
       return false if @email.nil?
       return false if @email.to_s.length > 254
       return false if @email.to_s.length < 5
+      return false if @email !~ Regexp.new(/^(?![^@]*\.\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,63}$/)
       return false if !@quota_bytes.nil? && @quota_bytes < 1
       true
     end
@@ -173,6 +179,11 @@ module Sendmux::Management::Generated
 
       if email.to_s.length < 5
         fail ArgumentError, 'invalid value for "email", the character length must be greater than or equal to 5.'
+      end
+
+      pattern = Regexp.new(/^(?![^@]*\.\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,63}$/)
+      if email !~ pattern
+        fail ArgumentError, "invalid value for \"email\", must conform to the pattern #{pattern}."
       end
 
       @email = email

--- a/packages/ruby/management/lib/sendmux_management_generated/models/management_create_mailbox_request.rb
+++ b/packages/ruby/management/lib/sendmux_management_generated/models/management_create_mailbox_request.rb
@@ -122,7 +122,7 @@ module Sendmux::Management::Generated
         invalid_properties.push('invalid value for "email", the character length must be greater than or equal to 5.')
       end
 
-      pattern = Regexp.new(/\A(?![^@]*\.\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,63}\z/)
+      pattern = Regexp.new(/\A(?![^\r\n]*[\r\n])(?![^@]*\.\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,63}\z/)
       if @email !~ pattern
         invalid_properties.push("invalid value for \"email\", must conform to the pattern #{pattern}.")
       end
@@ -143,7 +143,7 @@ module Sendmux::Management::Generated
       return false if @email.nil?
       return false if @email.to_s.length > 254
       return false if @email.to_s.length < 5
-      return false if @email !~ Regexp.new(/\A(?![^@]*\.\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,63}\z/)
+      return false if @email !~ Regexp.new(/\A(?![^\r\n]*[\r\n])(?![^@]*\.\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,63}\z/)
       return false if !@quota_bytes.nil? && @quota_bytes < 1
       true
     end
@@ -181,7 +181,7 @@ module Sendmux::Management::Generated
         fail ArgumentError, 'invalid value for "email", the character length must be greater than or equal to 5.'
       end
 
-      pattern = Regexp.new(/\A(?![^@]*\.\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,63}\z/)
+      pattern = Regexp.new(/\A(?![^\r\n]*[\r\n])(?![^@]*\.\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,63}\z/)
       if email !~ pattern
         fail ArgumentError, "invalid value for \"email\", must conform to the pattern #{pattern}."
       end

--- a/packages/ruby/management/lib/sendmux_management_generated/models/management_create_mailbox_request.rb
+++ b/packages/ruby/management/lib/sendmux_management_generated/models/management_create_mailbox_request.rb
@@ -122,7 +122,7 @@ module Sendmux::Management::Generated
         invalid_properties.push('invalid value for "email", the character length must be greater than or equal to 5.')
       end
 
-      pattern = Regexp.new(/^(?![^@]*\.\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,63}$/)
+      pattern = Regexp.new(/\A(?![^@]*\.\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,63}\z/)
       if @email !~ pattern
         invalid_properties.push("invalid value for \"email\", must conform to the pattern #{pattern}.")
       end
@@ -143,7 +143,7 @@ module Sendmux::Management::Generated
       return false if @email.nil?
       return false if @email.to_s.length > 254
       return false if @email.to_s.length < 5
-      return false if @email !~ Regexp.new(/^(?![^@]*\.\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,63}$/)
+      return false if @email !~ Regexp.new(/\A(?![^@]*\.\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,63}\z/)
       return false if !@quota_bytes.nil? && @quota_bytes < 1
       true
     end
@@ -181,7 +181,7 @@ module Sendmux::Management::Generated
         fail ArgumentError, 'invalid value for "email", the character length must be greater than or equal to 5.'
       end
 
-      pattern = Regexp.new(/^(?![^@]*\.\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,63}$/)
+      pattern = Regexp.new(/\A(?![^@]*\.\.)[a-zA-Z0-9_%+-](?:[a-zA-Z0-9._%+-]*[a-zA-Z0-9_%+-])?@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,63}\z/)
       if email !~ pattern
         fail ArgumentError, "invalid value for \"email\", must conform to the pattern #{pattern}."
       end

--- a/packages/ruby/tests/test_management_validation.rb
+++ b/packages/ruby/tests/test_management_validation.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'sendmux/management'
+
+class SendmuxRubyManagementValidationTest < Minitest::Test
+  def test_mailbox_email_validation_matches_the_full_value
+    assert_raises(ArgumentError) do
+      Sendmux::Management::Generated::ManagementCreateMailboxRequest.new(email: "x\nvalid@example.com")
+    end
+
+    request = Sendmux::Management::Generated::ManagementCreateMailboxRequest.new(email: 'valid@example.com')
+    assert_equal 'valid@example.com', request.email
+  end
+end

--- a/packages/ruby/tests/test_management_validation.rb
+++ b/packages/ruby/tests/test_management_validation.rb
@@ -5,8 +5,10 @@ require 'sendmux/management'
 
 class SendmuxRubyManagementValidationTest < Minitest::Test
   def test_mailbox_email_validation_matches_the_full_value
-    assert_raises(ArgumentError) do
-      Sendmux::Management::Generated::ManagementCreateMailboxRequest.new(email: "x\nvalid@example.com")
+    ["x\nvalid@example.com", "valid@example.com\n", "valid@example.com\r", "valid@example.com\r\n"].each do |email|
+      assert_raises(ArgumentError) do
+        Sendmux::Management::Generated::ManagementCreateMailboxRequest.new(email: email)
+      end
     end
 
     request = Sendmux::Management::Generated::ManagementCreateMailboxRequest.new(email: 'valid@example.com')

--- a/scripts/check-ruby.mjs
+++ b/scripts/check-ruby.mjs
@@ -22,6 +22,7 @@ runShell(`find packages/ruby -name '*.rb' -print0 | xargs -0 -n 1 ${ruby.join(" 
 checkRubyDependencyFloors();
 run(bundle, ["exec", "rubocop", "packages/ruby"]);
 run(bundle, ["exec", "ruby", "-Ipackages/ruby/tests", "packages/ruby/tests/test_core.rb"]);
+run(bundle, ["exec", "ruby", "-Ipackages/ruby/tests", "packages/ruby/tests/test_management_validation.rb"]);
 
 function commandWithRbenv(command) {
   if (existsSync(`${process.env.HOME}/.rbenv/bin/rbenv`) || existsSync("/opt/homebrew/bin/rbenv")) {

--- a/scripts/generate-ruby.mjs
+++ b/scripts/generate-ruby.mjs
@@ -95,6 +95,11 @@ for (const surface of surfaces) {
     recursive: true,
   });
   patchGeneratedApiClientHeaders(join(packageDir, "lib", surface.generatedGemName, "api_client.rb"));
+  if (surface.name === "management") {
+    patchGeneratedManagementMailboxEmailAnchors(
+      join(packageDir, "lib", surface.generatedGemName, "models", "management_create_mailbox_request.rb"),
+    );
+  }
   stripTrailingWhitespace(join(packageDir, "lib", `${surface.generatedGemName}.rb`));
   stripTrailingWhitespace(join(packageDir, "lib", surface.generatedGemName));
   writeSurfaceClient(surface, packageDir);
@@ -324,6 +329,20 @@ function patchGeneratedApiClientHeaders(apiClientPath) {
   writeFileSync(
     apiClientPath,
     source.replace(headerAssignment, patchedHeaderAssignment).replace(methodInsertionPoint, stringifyMethod + methodInsertionPoint),
+  );
+}
+
+function patchGeneratedManagementMailboxEmailAnchors(modelPath) {
+  const source = readFileSync(modelPath, "utf8");
+  const anchoredPattern = /Regexp\.new\(\/\^((?:\\.|[^/\n])*)\$\/\)/g;
+  const matches = source.match(anchoredPattern) ?? [];
+  if (matches.length !== 3) {
+    throw new Error(`Expected three anchored email validators in ${modelPath}; found ${matches.length}`);
+  }
+
+  writeFileSync(
+    modelPath,
+    source.replace(anchoredPattern, (_match, body) => `Regexp.new(/\\A${body}\\z/)`),
   );
 }
 

--- a/scripts/generate-ruby.mjs
+++ b/scripts/generate-ruby.mjs
@@ -334,7 +334,7 @@ function patchGeneratedApiClientHeaders(apiClientPath) {
 
 function patchGeneratedManagementMailboxEmailAnchors(modelPath) {
   const source = readFileSync(modelPath, "utf8");
-  const anchoredPattern = /Regexp\.new\(\/\^((?:\\.|[^/\n])*)\$\/\)/g;
+  const anchoredPattern = /Regexp\.new\(\/\^((?:\\.|[^\\/\n])*)\$\/\)/g;
   const matches = source.match(anchoredPattern) ?? [];
   if (matches.length !== 3) {
     throw new Error(`Expected three anchored email validators in ${modelPath}; found ${matches.length}`);


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR synchronizes mailbox-creation email validation across the generated Go, PHP, Python, and Ruby Management clients and the MCP OpenAPI snapshot.

- Adds a shared email-pattern validator to the Go Management client.
- Adds equivalent model-level validation to the PHP, Python, and Ruby clients.
- Updates the MCP App API snapshot with the corresponding schema pattern.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code defect identified.

The generated Management clients consistently apply the new mailbox email constraint, and the reviewed dependency and request-model contracts support the added validators.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| go/management/oas_cfg_gen.go | Adds the generated regex registry entry used by Management request validation. |
| go/management/oas_validators_gen.go | Applies the synchronized email pattern when validating mailbox-creation requests. |
| packages/php/management/src/Model/ManagementCreateMailboxRequest.php | Adds the email-pattern check to PHP model validation and assignment. |
| packages/python/management/sendmux_management/models/management_create_mailbox_request.py | Adds a Pydantic 2 field validator enforcing the mailbox email pattern. |
| packages/python/mcp/sendmux_mcp/openapi/openapi-app.json | Records the mailbox email constraint in the MCP package’s bundled OpenAPI schema. |
| packages/ruby/management/lib/sendmux_management_generated/models/management_create_mailbox_request.rb | Adds equivalent email-pattern checks to Ruby validation and assignment paths. |

<sub>Reviews (1): Last reviewed commit: ["fix: sync mailbox reliability clients"](https://github.com/sendmux/sendmux-sdk/commit/e8e7148e21f8fdba790c89331e8a2e144f86be4b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58843522)</sub>

<!-- /greptile_comment -->