### PR TITLE
chore(cli): publish Snap 1.5.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: sendmux
 title: Sendmux CLI
 base: core26
-version: "1.3.1"
+version: "1.5.0"
 summary: Official command-line interface for Sendmux email APIs
 description: |
   Manage Sendmux from Linux terminals and automation with the official Sendmux CLI.
@@ -40,9 +40,9 @@ apps:
 parts:
   sendmux:
     plugin: npm
-    source: https://registry.npmjs.org/@sendmux/cli/-/cli-1.3.1.tgz
+    source: https://registry.npmjs.org/@sendmux/cli/-/cli-1.5.0.tgz
     source-type: tar
-    source-checksum: sha512/dd989b4cd0d104cff712755bc37695e90eb95522bad040b535e3e0e1642430284e0b1981f6d7be9cf361febe81b89e132943b5c9aa46a337aa60acd431d51a08
+    source-checksum: sha512/42c3cbf2b6451b968d44f8ba3bf33d03569cefb80a01bea968f8864d4e66f2fa9e344147d5b5f2e16ebcdc49269537815cbf3671905b8145c70a7336339f77ea
     npm-include-node: true
     npm-node-version: "22.22.3"
 


### PR DESCRIPTION
Updates the Snap package from CLI 1.3.1 to the published CLI 1.5.0, including authenticated connection checks for Management, Mailbox and Sending. The version, npm tarball URL and SHA512 checksum match the verified registry artifact.

Validation: the CLI release passed full local and main CI, an installed npm consumer, authentication boundaries, and all five downloadable archive checks. The Snap workflow tests pass. The existing workflow builds amd64 and arm64 and publishes edge on merge; both revisions will be verified before the approved manual stable promotion.

Rollback: stable currently points to amd64 revision 99 and arm64 revision 100 (CLI 1.3.1).
