### PR TITLE
fix(python-sdk): require connection-capable components

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ Official SDK, CLI, and MCP workspace for Sendmux.
 | PyPI | `sendmux-sdk` | Python umbrella package | surface-specific | `pip install sendmux-sdk` | [`packages/python/sdk`](packages/python/sdk) |
 | PyPI | `sendmux-mcp` | Local MCP plus hosted MCP and A2A servers | OAuth for hosted; surface-specific keys for local | `pip install sendmux-mcp` | [`packages/python/mcp`](packages/python/mcp) |
 | PyPI | `langchain-sendmux` | LangChain toolkit (agent inbox + sending) | send + receive `smx_mbx_*` or `smx_agent_*` | `pip install langchain-sendmux` | [`packages/python/langchain`](packages/python/langchain) |
-| Go | `sendmux.ai/go/core` | Shared Go helpers | n/a | `go get sendmux.ai/go@v1.4.1` | [`go/core`](go/core) |
-| Go | `sendmux.ai/go/sending` | Sending API | `smx_mbx_*` or owner-approved `smx_agent_*` | `go get sendmux.ai/go@v1.4.1` | [`go/sending`](go/sending) |
-| Go | `sendmux.ai/go/mailbox` | Mailbox API | `smx_mbx_*` or `smx_agent_*` | `go get sendmux.ai/go@v1.4.1` | [`go/mailbox`](go/mailbox) |
-| Go | `sendmux.ai/go/management` | Management API | `smx_root_*` | `go get sendmux.ai/go@v1.4.1` | [`go/management`](go/management) |
-| Go | `sendmux.ai/go/sdk` | Go umbrella package | surface-specific | `go get sendmux.ai/go@v1.4.1` | [`go/sdk`](go/sdk) |
+| Go | `sendmux.ai/go/core` | Shared Go helpers | n/a | `go get sendmux.ai/go@v1.5.0` | [`go/core`](go/core) |
+| Go | `sendmux.ai/go/sending` | Sending API | `smx_mbx_*` or owner-approved `smx_agent_*` | `go get sendmux.ai/go@v1.5.0` | [`go/sending`](go/sending) |
+| Go | `sendmux.ai/go/mailbox` | Mailbox API | `smx_mbx_*` or `smx_agent_*` | `go get sendmux.ai/go@v1.5.0` | [`go/mailbox`](go/mailbox) |
+| Go | `sendmux.ai/go/management` | Management API | `smx_root_*` | `go get sendmux.ai/go@v1.5.0` | [`go/management`](go/management) |
+| Go | `sendmux.ai/go/sdk` | Go umbrella package | surface-specific | `go get sendmux.ai/go@v1.5.0` | [`go/sdk`](go/sdk) |
 | crates.io | `sendmux` | Rust umbrella crate | surface-specific | `cargo add sendmux` | [`rust`](rust) |
 | Packagist | `sendmux/core` | Shared PHP helpers | n/a | `composer require sendmux/core:^1.0` | [`packages/php/core`](packages/php/core) |
 | Packagist | `sendmux/sending` | Sending API | `smx_mbx_*` or owner-approved `smx_agent_*` | `composer require sendmux/sending:^1.0` | [`packages/php/sending`](packages/php/sending) |
@@ -59,7 +59,7 @@ Install only the package for the surface you need.
 ```sh
 npm install @sendmux/sending
 pip install sendmux-sending
-go get sendmux.ai/go@v1.4.1
+go get sendmux.ai/go@v1.5.0
 cargo add sendmux
 composer require sendmux/sending:^1.0
 gem install sendmux-sending

--- a/packages/python/sdk/README.md
+++ b/packages/python/sdk/README.md
@@ -28,6 +28,33 @@ Optional umbrella package for the Sendmux Python SDK.
 pip install sendmux-sdk
 ```
 
+## Connection checks
+
+Check a Management credential without creating resources:
+
+```python
+import os
+
+from sendmux_sdk import management
+
+with management.create_management_client(
+    api_key=os.environ["SENDMUX_MANAGEMENT_API_KEY"]
+) as client:
+    connection = management.ConnectionApi(client).management_get_connection()
+    print(connection.data.label, connection.data.team.id)
+```
+
+Use `data.label` for the connection name and `data.team.id` for its stable team
+identifier. Each API surface has its own connection operation:
+
+| Surface | API class | Method |
+| --- | --- | --- |
+| Management | `management.ConnectionApi` | `management_get_connection()` |
+| Mailbox | `mailbox.MailboxAPIApi` | `mailbox_get_connection()` |
+| Sending | `sending.MetaApi` | `sending_get_connection()` |
+
+Create each client with the credential for that surface.
+
 ## Usage
 
 ```python

--- a/packages/python/sdk/pyproject.toml
+++ b/packages/python/sdk/pyproject.toml
@@ -19,9 +19,9 @@ classifiers = [
 ]
 dependencies = [
   "sendmux-core>=1.2.0,<2.0.0",
-  "sendmux-mailbox>=1.0.4,<2.0.0",
-  "sendmux-management>=1.0.4,<2.0.0",
-  "sendmux-sending>=1.1.0,<2.0.0",
+  "sendmux-mailbox>=1.4.0,<2.0.0",
+  "sendmux-management>=1.3.0,<2.0.0",
+  "sendmux-sending>=1.4.0,<2.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
The Python umbrella package allowed older component versions that do not expose connection checks. Require Sending 1.4.0, Mailbox 1.4.0 and Management 1.3.0, and document the side-effect-free connection operations through the umbrella imports. Update the root Go install commands to the published 1.5.0 tag.

Validation: a fresh installation at the previous dependency floors failed all three connection-operation checks. The built umbrella wheel with the corrected minimum dependencies passes all three authenticated GET and 401 transport cases. Generated-client drift, live OpenAPI canary, mypy (50 files), pytest (63 passed, no skips), and all seven distribution builds/Twine checks passed. This source change prepares the normal Python umbrella release; it does not publish over 1.1.0.
