### PR TITLE
fix(python-mcp): honour server retry policy and retry budgets

### DIFF
--- a/packages/python/mcp/README.md
+++ b/packages/python/mcp/README.md
@@ -135,6 +135,9 @@ The A2A endpoint is immediate and stateless: streaming, push notifications, pers
 | Sending snapshot override | `SENDMUX_MCP_SENDING_OPENAPI` | packaged sending snapshot |
 | Request timeout | `SENDMUX_MCP_TIMEOUT_SECONDS` | `30` |
 | Retry attempts | `SENDMUX_MCP_RETRY_MAX_ATTEMPTS` | `3` |
+| Retry time budget, in seconds | `SENDMUX_MCP_RETRY_MAX_ELAPSED_SECONDS` | unset |
+
+Retries honour `Retry-After` and `X-RateLimit-Reset` without applying the local backoff ceiling, and stop for `retryable: false`. Set the optional retry budget with `RetryConfig(max_elapsed_seconds=30)`, the environment variable above, or `--retry-max-elapsed-seconds 30`. A retry that would exceed the remaining budget returns the original error; in-flight requests keep their normal HTTP timeouts.
 
 Packaged OpenAPI snapshots are the default so released tool names, schemas, and descriptions stay stable. Path, directory, and URL overrides are available for development, canary, and debugging runs.
 

--- a/packages/python/mcp/pyproject.toml
+++ b/packages/python/mcp/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   "fastmcp==3.3.1",
   "httpx>=0.28.1,<1",
   "posthog>=7.21.0,<8",
-  "sendmux-core>=1.2.0,<2.0.0",
+  "sendmux-core>=1.3.0,<2.0.0",
 ]
 
 [project.scripts]

--- a/packages/python/mcp/sendmux_mcp/cli.py
+++ b/packages/python/mcp/sendmux_mcp/cli.py
@@ -72,6 +72,7 @@ def parser(*, default_surface: Surface | None = None, prog: str) -> argparse.Arg
     command.add_argument("--retry-max-attempts", type=int)
     command.add_argument("--retry-base-delay-seconds", type=float)
     command.add_argument("--retry-max-delay-seconds", type=float)
+    command.add_argument("--retry-max-elapsed-seconds", type=float)
     command.set_defaults(surface=default_surface)
     return command
 
@@ -117,6 +118,10 @@ def config_from_args(surfaces: tuple[Surface, ...], args: argparse.Namespace) ->
             max_attempts=args.retry_max_attempts or base.retry.max_attempts,
             base_delay_seconds=args.retry_base_delay_seconds or base.retry.base_delay_seconds,
             max_delay_seconds=args.retry_max_delay_seconds or base.retry.max_delay_seconds,
+            max_elapsed_seconds=(
+                args.retry_max_elapsed_seconds
+                if args.retry_max_elapsed_seconds is not None else base.retry.max_elapsed_seconds
+            ),
         ),
     )
 

--- a/packages/python/mcp/sendmux_mcp/config.py
+++ b/packages/python/mcp/sendmux_mcp/config.py
@@ -21,6 +21,7 @@ class RetryConfig:
     max_attempts: int = 3
     base_delay_seconds: float = 0.25
     max_delay_seconds: float = 8.0
+    max_elapsed_seconds: float | None = None
 
 
 @dataclass(frozen=True)
@@ -108,6 +109,7 @@ def config_from_env(
         surfaces if surfaces is not None else parse_surfaces(os.environ.get("SENDMUX_MCP_SURFACES"), default=("mailbox",))
     )
     env_api_keys = surface_api_keys_from_env()
+    retry_max_elapsed = os.environ.get("SENDMUX_MCP_RETRY_MAX_ELAPSED_SECONDS")
     return ServerConfig(
         surfaces=selected_surfaces,
         api_key=api_key or os.environ.get("SENDMUX_API_KEY") or None,
@@ -130,6 +132,7 @@ def config_from_env(
             max_attempts=int(os.environ.get("SENDMUX_MCP_RETRY_MAX_ATTEMPTS", "3")),
             base_delay_seconds=float(os.environ.get("SENDMUX_MCP_RETRY_BASE_DELAY_SECONDS", "0.25")),
             max_delay_seconds=float(os.environ.get("SENDMUX_MCP_RETRY_MAX_DELAY_SECONDS", "8")),
+            max_elapsed_seconds=float(retry_max_elapsed) if retry_max_elapsed else None,
         ),
     )
 

--- a/packages/python/mcp/sendmux_mcp/retry.py
+++ b/packages/python/mcp/sendmux_mcp/retry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import random
+import time
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
@@ -28,6 +29,10 @@ class RetryingAsyncTransport(httpx.AsyncBaseTransport):
         self._sleep = sleep
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        deadline = (
+            float("inf") if self.retry.max_elapsed_seconds is None
+            else time.monotonic() + max(0.0, self.retry.max_elapsed_seconds)
+        )
         body = await request.aread()
         attempts = max(1, self.retry.max_attempts)
         last_error: httpx.TransportError | None = None
@@ -40,15 +45,18 @@ class RetryingAsyncTransport(httpx.AsyncBaseTransport):
                 last_error = exc
                 if attempt + 1 >= attempts or not can_retry_request(request):
                     raise
-                await self.sleep(delay_for_attempt(attempt, self.retry))
+                if not await self._wait_for_retry(delay_for_attempt(attempt, self.retry), deadline):
+                    raise
                 continue
 
-            if attempt + 1 >= attempts or not should_retry_response(request, response):
+            if attempt + 1 >= attempts or not await should_retry_response(request, response):
                 return response
 
             delay = retry_delay(response, attempt, self.retry)
+            await response.aread()
             await response.aclose()
-            await self.sleep(delay)
+            if not await self._wait_for_retry(delay, deadline):
+                return response
 
         if last_error is not None:
             raise last_error
@@ -56,6 +64,12 @@ class RetryingAsyncTransport(httpx.AsyncBaseTransport):
 
     async def aclose(self) -> None:
         await self.inner.aclose()
+
+    async def _wait_for_retry(self, delay: float, deadline: float) -> bool:
+        if time.monotonic() + delay >= deadline:
+            return False
+        await self.sleep(delay)
+        return time.monotonic() < deadline
 
     async def sleep(self, seconds: float) -> None:
         if seconds <= 0:
@@ -78,8 +92,20 @@ def clone_request(request: httpx.Request, body: bytes) -> httpx.Request:
     )
 
 
-def should_retry_response(request: httpx.Request, response: httpx.Response) -> bool:
-    return response.status_code in RETRY_STATUSES and can_retry_request(request)
+async def should_retry_response(request: httpx.Request, response: httpx.Response) -> bool:
+    if response.status_code not in RETRY_STATUSES or not can_retry_request(request):
+        return False
+    if "application/json" not in response.headers.get("Content-Type", "").lower():
+        return True
+    await response.aread()
+    try:
+        payload = response.json()
+    except (ValueError, UnicodeDecodeError):
+        return True
+    return not (
+        isinstance(payload, dict) and payload.get("ok") is False
+        and isinstance(payload.get("error"), dict) and payload["error"].get("retryable") is False
+    )
 
 
 def can_retry_request(request: httpx.Request) -> bool:
@@ -91,11 +117,11 @@ def can_retry_request(request: httpx.Request) -> bool:
 def retry_delay(response: httpx.Response, attempt: int, retry: RetryConfig) -> float:
     retry_after = parse_retry_after(response.headers.get("Retry-After"))
     if retry_after is not None:
-        return min(retry_after, retry.max_delay_seconds)
+        return retry_after
 
     reset = parse_rate_limit_reset(response.headers.get("X-RateLimit-Reset"))
     if reset is not None:
-        return min(reset, retry.max_delay_seconds)
+        return reset
 
     return delay_for_attempt(attempt, retry)
 

--- a/packages/python/tests/test_mcp_retry.py
+++ b/packages/python/tests/test_mcp_retry.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any
+
+import httpx
+import pytest
+from fastmcp import Client
+
+import sendmux_mcp.retry as retry_module
+from sendmux_mcp.cli import config_from_args, parser
+from sendmux_mcp.config import RetryConfig, ServerConfig, Surface
+from sendmux_mcp.retry import RetryingAsyncTransport
+from sendmux_mcp.server import create_server
+from sendmux_mcp.verification import structured_result
+
+
+@pytest.mark.parametrize("headers", [
+    {"Retry-After": "120"},
+    {"Retry-After": "Wed, 09 Sep 2026 00:02:00 GMT"},
+    {"X-RateLimit-Reset": "1788912120"},
+])
+def test_mcp_send_waits_for_server_delay_without_capping(
+    headers: dict[str, str], monkeypatch: Any,
+) -> None:
+    requests: list[httpx.Request] = []
+    delays: list[float] = []
+
+    class FrozenDatetime(datetime):
+        @classmethod
+        def now(cls, tz: Any = None) -> FrozenDatetime:
+            return cls(2026, 9, 9, tzinfo=timezone.utc)
+
+    async def sleep(seconds: float) -> None:
+        delays.append(seconds)
+
+    monkeypatch.setattr(retry_module, "asyncio", SimpleNamespace(sleep=sleep))
+    monkeypatch.setattr(retry_module, "datetime", FrozenDatetime)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if len(requests) == 1:
+            return httpx.Response(429, headers=headers, json={
+                "ok": False,
+                "error": {"code": "rate_limited", "message": "Retry later.", "retryable": True},
+                "meta": {"request_id": "req_test"},
+            })
+        return httpx.Response(200, json={
+            "ok": True, "data": {"id": "sub_test", "status": "queued"},
+            "meta": {"request_id": "req_test"},
+        })
+
+    async def check() -> None:
+        server = create_server(
+            ServerConfig(surfaces=("mailbox",), api_key="smx_mbx_test", retry=RetryConfig(max_attempts=2)),
+            transport=httpx.MockTransport(handler),
+        )
+        async with Client(server) as client:
+            result = structured_result(await client.call_tool("mailbox_send_message", {
+                "Idempotency-Key": "mcp-retry-test", "subject": "Retry test",
+                "text_body": "Retry test.", "to": [{"email": "agent@example.com", "name": None}],
+            }))
+        assert result["ok"] is True
+
+    asyncio.run(check())
+    assert delays == [120.0]
+    assert len(requests) == 2
+    assert all(request.headers["Idempotency-Key"] == "mcp-retry-test" for request in requests)
+    assert requests[0].content == requests[1].content
+
+
+@pytest.mark.parametrize("configuration", ["python", "environment", "cli"])
+def test_mcp_deadline_returns_original_error_without_early_retry(
+    configuration: str, monkeypatch: Any,
+) -> None:
+    requests: list[httpx.Request] = []
+    delays: list[float] = []
+
+    async def sleep(seconds: float) -> None:
+        delays.append(seconds)
+
+    monkeypatch.setattr(retry_module, "asyncio", SimpleNamespace(sleep=sleep))
+    monkeypatch.setattr(retry_module, "time", SimpleNamespace(monotonic=lambda: 1000.0), raising=False)
+    if configuration == "python":
+        config = ServerConfig(
+            surfaces=("management",), api_key="smx_root_test", retry=RetryConfig(max_elapsed_seconds=30),
+        )
+    else:
+        arguments = ["--api-key", "smx_root_test"]
+        if configuration == "environment":
+            monkeypatch.setenv("SENDMUX_MCP_RETRY_MAX_ELAPSED_SECONDS", "30")
+        else:
+            arguments.extend(["--retry-max-elapsed-seconds", "30"])
+        config = config_from_args(("management",), parser(prog="sendmux-mcp").parse_args(arguments))
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(429, headers={"Retry-After": "120"}, json={
+            "ok": False,
+            "error": {"code": "rate_limited", "message": "Retry later.", "retryable": True},
+            "meta": {"request_id": "req_deadline"},
+        })
+
+    async def check() -> None:
+        server = create_server(config, transport=httpx.MockTransport(handler))
+        async with Client(server) as client:
+            result = await client.call_tool_mcp("management_get_connection", {})
+        assert len(requests) == 1
+        assert delays == []
+        assert result.isError is True
+        assert "rate_limited" in str(result.content)
+        assert "req_deadline" in str(result.content)
+
+    asyncio.run(check())
+
+
+@pytest.mark.parametrize("surface", ["mailbox", "management", "sending"])
+def test_mcp_connection_does_not_retry_explicit_terminal_error(surface: Surface) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(429, headers={"Retry-After": "0"}, json={
+            "ok": False,
+            "error": {"code": "rate_limited", "message": "Retry later.", "retryable": False},
+            "meta": {"request_id": "req_original"},
+        })
+
+    async def check() -> None:
+        server = create_server(
+            ServerConfig(
+                surfaces=(surface,), api_key="smx_root_test" if surface == "management" else "smx_mbx_test",
+                retry=RetryConfig(max_attempts=3, base_delay_seconds=0, max_delay_seconds=0),
+            ),
+            transport=httpx.MockTransport(handler),
+        )
+        async with Client(server) as client:
+            result = await client.call_tool_mcp(f"{surface}_get_connection", {})
+        assert len(requests) == 1
+        assert result.isError is True
+        assert "rate_limited" in str(result.content)
+        assert "req_original" in str(result.content)
+
+    asyncio.run(check())
+
+
+@pytest.mark.parametrize("content_type,payload", [
+    ("application/json", b'{"ok":false,"error":{"code":"unavailable","retryable":true}}'),
+    ("text/plain", b"Temporarily unavailable."),
+])
+def test_expired_retry_budget_preserves_original_response(
+    content_type: str, payload: bytes, monkeypatch: Any,
+) -> None:
+    now = [1000.0]
+    requests: list[httpx.Request] = []
+    delays: list[float] = []
+    monkeypatch.setattr(retry_module, "time", SimpleNamespace(monotonic=lambda: now[0]))
+
+    async def sleep(seconds: float) -> None:
+        delays.append(seconds)
+        now[0] += 30
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if len(requests) > 1:
+            return httpx.Response(200, json={"ok": True})
+        return httpx.Response(503, content=payload, headers={
+            "Content-Type": content_type, "Retry-After": "10", "X-Request-Id": "req_expired",
+        })
+
+    async def check() -> None:
+        transport = RetryingAsyncTransport(
+            retry=RetryConfig(max_attempts=2, max_elapsed_seconds=20),
+            inner=httpx.MockTransport(handler), sleep=sleep,
+        )
+        async with httpx.AsyncClient(transport=transport) as client:
+            response = await client.get("https://smtp.sendmux.ai/api/v1/me")
+        assert response.status_code == 503
+        assert response.content == payload
+        assert response.headers["Retry-After"] == "10"
+        assert response.headers["X-Request-Id"] == "req_expired"
+
+    asyncio.run(check())
+    assert len(requests) == 1
+    assert delays == [10.0]
+
+
+def test_exhausted_retry_budget_preserves_transport_error(monkeypatch: Any) -> None:
+    requests: list[httpx.Request] = []
+    delays: list[float] = []
+    failure = httpx.ConnectError("Fixture transport failure.")
+    monkeypatch.setattr(retry_module, "time", SimpleNamespace(monotonic=lambda: 1000.0), raising=False)
+
+    async def sleep(seconds: float) -> None:
+        delays.append(seconds)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if len(requests) == 1:
+            raise failure
+        return httpx.Response(200, json={"ok": True})
+
+    async def check() -> None:
+        transport = RetryingAsyncTransport(
+            retry=RetryConfig(max_attempts=2, max_elapsed_seconds=0),
+            inner=httpx.MockTransport(handler), sleep=sleep,
+        )
+        async with httpx.AsyncClient(transport=transport) as client:
+            with pytest.raises(httpx.ConnectError, match="Fixture transport failure") as raised:
+                await client.get("https://smtp.sendmux.ai/api/v1/me")
+        assert raised.value is failure
+
+    asyncio.run(check())
+    assert len(requests) == 1
+    assert delays == []

--- a/scripts/check-mcp.mjs
+++ b/scripts/check-mcp.mjs
@@ -29,7 +29,7 @@ run(python, [
 ]);
 run(python, ["-m", "compileall", "-q", "packages/python/mcp"]);
 run(python, ["-m", "mypy", "packages/python/mcp"]);
-run(python, ["-m", "pytest", "packages/python/tests/test_mcp.py", "packages/python/mcp/tests"]);
+run(python, ["-m", "pytest", "packages/python/tests/test_mcp.py", "packages/python/tests/test_mcp_retry.py", "packages/python/mcp/tests"]);
 rmSync(distDir, { force: true, recursive: true });
 mkdirSync(distDir, { recursive: true });
 run(python, ["-m", "build", "--outdir", distDir, "packages/python/mcp"]);


### PR DESCRIPTION
MCP retries previously shortened a server-requested 120-second delay to 8 seconds and retried responses carrying `retryable: false`. Honour the full server delay and terminal-error flag in the shared local/hosted transport. Add an optional retry time budget through Python configuration, environment and CLI; preserve the original response or transport error when another retry cannot fit. Existing request timeouts and idempotency rules remain in effect.

Raise the MCP dependency floor to the published `sendmux-core>=1.3.0` and include the new regression file in the standalone MCP gate.

Validation: all 12 new regression cases were observed failing before their corresponding fixes and now pass. `pnpm build` passes, including 103 Python tests, 90 MCP/hosted tests and the existing connection adapter checks; `pnpm canary:openapi` confirms live contracts match the snapshots. The MCP suite retains 22 existing A2A deprecation warnings. Production verification follows the package and hosted release; this PR does not deploy it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable retry time limits through the CLI, environment variables, and Python settings.
  - Retry waits now respect server-provided delay and rate-limit guidance.

- **Bug Fixes**
  - Improved retry handling for deadlines, non-retryable errors, terminal responses, and transport failures.
  - Responses and exceptions are preserved when no further retry is possible.

- **Documentation**
  - Documented retry time-budget configuration and clarified retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->