### PR TITLE
fix: resolve TypeScript credential providers once per request

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,9 @@
       "protobufjs": "7.6.5",
       "shell-quote": "1.9.0",
       "undici": "6.28.0"
+    },
+    "patchedDependencies": {
+      "@hey-api/openapi-ts@0.97.3": "patches/@hey-api__openapi-ts@0.97.3.patch"
     }
   }
 }

--- a/packages/ts/mailbox/src/generated/client/utils.gen.ts
+++ b/packages/ts/mailbox/src/generated/client/utils.gen.ts
@@ -106,7 +106,7 @@ const checkForExistence = (
   name?: string,
 ): boolean => {
   if (!name) {
-    return false;
+    return options.headers.has('Authorization');
   }
   if (
     options.headers.has(name) ||

--- a/packages/ts/management/src/generated/client/utils.gen.ts
+++ b/packages/ts/management/src/generated/client/utils.gen.ts
@@ -106,7 +106,7 @@ const checkForExistence = (
   name?: string,
 ): boolean => {
   if (!name) {
-    return false;
+    return options.headers.has('Authorization');
   }
   if (
     options.headers.has(name) ||

--- a/packages/ts/sdk/README.md
+++ b/packages/ts/sdk/README.md
@@ -62,7 +62,7 @@ const response = await sending.sendingSendEmail({
   },
 });
 
-console.log(response.data.message_id);
+console.log(response.data?.data.message_id);
 ```
 
 The umbrella package re-exports:

--- a/packages/ts/sending/README.md
+++ b/packages/ts/sending/README.md
@@ -60,7 +60,7 @@ const response = await sendingSendEmail({
   },
 });
 
-console.log(response.data.message_id);
+console.log(response.data?.data.message_id);
 ```
 
 The package exports every generated Sending operation plus:

--- a/packages/ts/sending/src/generated/client/utils.gen.ts
+++ b/packages/ts/sending/src/generated/client/utils.gen.ts
@@ -106,7 +106,7 @@ const checkForExistence = (
   name?: string,
 ): boolean => {
   if (!name) {
-    return false;
+    return options.headers.has('Authorization');
   }
   if (
     options.headers.has(name) ||

--- a/patches/@hey-api__openapi-ts@0.97.3.patch
+++ b/patches/@hey-api__openapi-ts@0.97.3.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/clients/fetch/utils.ts b/dist/clients/fetch/utils.ts
+index 29ebb80e4a91b3ad4db41f9009ee238ac6e48d09..cb3447cbc2fc8b8b038a4609f2756398a98448a9 100644
+--- a/dist/clients/fetch/utils.ts
++++ b/dist/clients/fetch/utils.ts
+@@ -104,7 +104,7 @@ const checkForExistence = (
+   name?: string,
+ ): boolean => {
+   if (!name) {
+-    return false;
++    return options.headers.has('Authorization');
+   }
+   if (
+     options.headers.has(name) ||

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,11 @@ overrides:
   shell-quote: 1.9.0
   undici: 6.28.0
 
+patchedDependencies:
+  '@hey-api/openapi-ts@0.97.3':
+    hash: 07847db1d946c3674909a4553717ae029683c136787d2fc300b00a29418981b9
+    path: patches/@hey-api__openapi-ts@0.97.3.patch
+
 importers:
 
   .:
@@ -22,7 +27,7 @@ importers:
         version: 0.14.2
       '@hey-api/openapi-ts':
         specifier: 0.97.3
-        version: 0.97.3(typescript@5.9.3)
+        version: 0.97.3(patch_hash=07847db1d946c3674909a4553717ae029683c136787d2fc300b00a29418981b9)(typescript@5.9.3)
       '@openapitools/openapi-generator-cli':
         specifier: 2.32.0
         version: 2.32.0
@@ -2717,7 +2722,7 @@ snapshots:
       '@types/json-schema': 7.0.15
       js-yaml: 4.3.1
 
-  '@hey-api/openapi-ts@0.97.3(typescript@5.9.3)':
+  '@hey-api/openapi-ts@0.97.3(patch_hash=07847db1d946c3674909a4553717ae029683c136787d2fc300b00a29418981b9)(typescript@5.9.3)':
     dependencies:
       '@hey-api/codegen-core': 0.8.2
       '@hey-api/json-schema-ref-parser': 1.4.2

--- a/scripts/test-ts-helpers.mjs
+++ b/scripts/test-ts-helpers.mjs
@@ -50,11 +50,69 @@ for (const [surface, createClient, getConnection] of [
     const staticClient = createClient({ accessToken: "access-token-one", fetch });
     await getConnection({ client: staticClient });
     let token = "access-token-two";
-    const refreshingClient = createClient({ accessToken: async () => token, fetch });
+    let providerCalls = 0;
+    const refreshingClient = createClient({ accessToken: async () => { providerCalls += 1; return token; }, fetch });
+    assert.equal(providerCalls, 0);
     await getConnection({ client: refreshingClient });
     token = "access-token-three";
     await getConnection({ client: refreshingClient });
     assert.deepEqual(observed, ["Bearer access-token-one", "Bearer access-token-two", "Bearer access-token-three"]);
+    assert.equal(providerCalls, 2);
+  });
+
+  await test(`${surface} resolves API-key providers once per request`, async () => {
+    const prefix = surface === "management" ? "smx_root_" : "smx_mbx_";
+    let providerCalls = 0;
+    const observed = [];
+    const client = createClient({
+      apiKey: async () => `${prefix}test_${++providerCalls}`,
+      fetch: async (request) => {
+        observed.push(request.headers.get("Authorization"));
+        return Response.json({});
+      },
+    });
+    assert.equal(providerCalls, 0);
+    await getConnection({ client });
+    await getConnection({ client });
+    assert.deepEqual(observed, [`Bearer ${prefix}test_1`, `Bearer ${prefix}test_2`]);
+    assert.equal(providerCalls, 2);
+  });
+
+  await test(`${surface} resolves independent access tokens for concurrent requests`, async () => {
+    let providerCalls = 0;
+    const observed = [];
+    const client = createClient({
+      accessToken: async () => {
+        const token = `token-${++providerCalls}`;
+        await nextTurn();
+        return token;
+      },
+      fetch: async (request) => {
+        observed.push(request.headers.get("Authorization"));
+        return Response.json({});
+      },
+    });
+    await Promise.all([getConnection({ client }), getConnection({ client })]);
+    assert.deepEqual(observed.sort(), ["Bearer token-1", "Bearer token-2"]);
+    assert.equal(providerCalls, 2);
+  });
+
+  await test(`${surface} recognises explicit bearer headers without confusing query or cookie values`, async () => {
+    let providerCalls = 0;
+    const observed = [];
+    const client = createClient({
+      accessToken: async () => { providerCalls += 1; return "provider-token"; },
+      fetch: async (request) => {
+        observed.push(request.headers.get("Authorization"));
+        return Response.json({});
+      },
+    });
+    await getConnection({ client, headers: { authorization: "Bearer explicit-token" } });
+    assert.equal(providerCalls, 0);
+    await getConnection({ client, query: { Authorization: "query-value" } });
+    await getConnection({ client, headers: { Cookie: "Authorization=cookie-value" } });
+    assert.deepEqual(observed, ["Bearer explicit-token", "Bearer provider-token", "Bearer provider-token"]);
+    assert.equal(providerCalls, 2);
   });
 
   await test(`${surface} rejects missing, ambiguous or malformed credentials before making a request`, async () => {


### PR DESCRIPTION
Endpoints with API-key and OAuth bearer alternatives called credential providers twice per request and overwrote an explicit Authorization header. Patch the pinned generator's implicit-header existence check, then regenerate Sending, Mailbox and Management clients. Credential resolution stays independent between requests, and query or cookie values named Authorization cannot suppress the bearer header.

Also correct the Sending and umbrella README examples to read the message ID from the nested API envelope returned by the generated transport.

Validation:
- Full `pnpm build` passed, including regeneration/drift, native language checks, CLI/MCP and connection adapters; live OpenAPI canary passed.
- All 24 TypeScript helper tests passed. Nine new cases and three strengthened OAuth cases failed before the patch; no tests removed or skipped.
- Both complete README Usage blocks passed strict NodeNext type-checking against installed packages.
- Installed tarballs with published Core 1.2.0 passed the complete OAuth, API-key, invalid-credential, provider-failure and terminal-error checks on all three surfaces, plus idempotent send replay for Sending. Error checks verify the existing `SendmuxApiError.cause` contract; credential failures make no HTTP request. All temporary consumers and HTTP servers were verified closed.

The package versions are unchanged here. Release Please will carry the fix into the pending leaf/umbrella releases and their changelogs; Sending release #202 remains held until this source fix and installed-package verification are complete.
