### PR TITLE
docs: link SDK README directly to the MCP guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Official SDK, CLI, and MCP workspace for Sendmux.
 - Management API reference: [sendmux.ai/docs/api/introduction](https://sendmux.ai/docs/api/introduction)
 - Mailbox API reference: [sendmux.ai/docs/mailbox-api/introduction](https://sendmux.ai/docs/mailbox-api/introduction)
 - Sending API reference: [sendmux.ai/docs/sending-api/introduction](https://sendmux.ai/docs/sending-api/introduction)
-- MCP guide: [sendmux.ai/docs/guides/mcp](https://sendmux.ai/docs/guides/mcp)
+- MCP guide: [sendmux.ai/docs/ai-integrations/mcp](https://sendmux.ai/docs/ai-integrations/mcp)
 
 ## Packages
 


### PR DESCRIPTION
Point the SDK root README directly at the MCP guide in `ai-integrations/mcp`, matching the documentation navigation instead of relying on the former `guides/mcp` redirect.

Validation: all six unique root README docs destinations checked against the owning docs source and redirects; five resolve to committed pages. The OAuth guide is already prepared and remains part of the matching docs publication. Live URL verification is unavailable because the web tool refused these docs URLs; no live-success claim. `git diff --check` passed.
