### PR TITLE
fix(sdk): preserve streaming arguments and prepare PHP OAuth release

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,17 @@ Official SDK, CLI, and MCP workspace for Sendmux.
 | PyPI | `sendmux-sdk` | Python umbrella package | surface-specific | `pip install sendmux-sdk` | [`packages/python/sdk`](packages/python/sdk) |
 | PyPI | `sendmux-mcp` | Local MCP plus hosted MCP and A2A servers | OAuth for hosted; surface-specific keys for local | `pip install sendmux-mcp` | [`packages/python/mcp`](packages/python/mcp) |
 | PyPI | `langchain-sendmux` | LangChain toolkit (agent inbox + sending) | REST OAuth or send + receive `smx_mbx_*` / `smx_agent_*` | `pip install langchain-sendmux` | [`packages/python/langchain`](packages/python/langchain) |
-| Go | `sendmux.ai/go/core` | Shared Go helpers | n/a | `go get sendmux.ai/go@v1.5.0` | [`go/core`](go/core) |
-| Go | `sendmux.ai/go/sending` | Sending API | `smx_mbx_*` or owner-approved `smx_agent_*` | `go get sendmux.ai/go@v1.5.0` | [`go/sending`](go/sending) |
-| Go | `sendmux.ai/go/mailbox` | Mailbox API | `smx_mbx_*` or `smx_agent_*` | `go get sendmux.ai/go@v1.5.0` | [`go/mailbox`](go/mailbox) |
-| Go | `sendmux.ai/go/management` | Management API | `smx_root_*` | `go get sendmux.ai/go@v1.5.0` | [`go/management`](go/management) |
-| Go | `sendmux.ai/go/sdk` | Go umbrella package | surface-specific | `go get sendmux.ai/go@v1.5.0` | [`go/sdk`](go/sdk) |
+| Go | `sendmux.ai/go/core` | Shared Go helpers | n/a | `go get sendmux.ai/go@v1.6.0` | [`go/core`](go/core) |
+| Go | `sendmux.ai/go/sending` | Sending API | `smx_mbx_*` or owner-approved `smx_agent_*` | `go get sendmux.ai/go@v1.6.0` | [`go/sending`](go/sending) |
+| Go | `sendmux.ai/go/mailbox` | Mailbox API | `smx_mbx_*` or `smx_agent_*` | `go get sendmux.ai/go@v1.6.0` | [`go/mailbox`](go/mailbox) |
+| Go | `sendmux.ai/go/management` | Management API | `smx_root_*` | `go get sendmux.ai/go@v1.6.0` | [`go/management`](go/management) |
+| Go | `sendmux.ai/go/sdk` | Go umbrella package | surface-specific | `go get sendmux.ai/go@v1.6.0` | [`go/sdk`](go/sdk) |
 | crates.io | `sendmux` | Rust umbrella crate | surface-specific | `cargo add sendmux` | [`rust`](rust) |
-| Packagist | `sendmux/core` | Shared PHP helpers | n/a | `composer require sendmux/core:^2.0` | [`packages/php/core`](packages/php/core) |
-| Packagist | `sendmux/sending` | Sending API | `smx_mbx_*` or owner-approved `smx_agent_*` | `composer require sendmux/sending:^2.0` | [`packages/php/sending`](packages/php/sending) |
-| Packagist | `sendmux/mailbox` | Mailbox API | `smx_mbx_*` or `smx_agent_*` | `composer require sendmux/mailbox:^2.0` | [`packages/php/mailbox`](packages/php/mailbox) |
-| Packagist | `sendmux/management` | Management API | `smx_root_*` | `composer require sendmux/management:^2.0` | [`packages/php/management`](packages/php/management) |
-| Packagist | `sendmux/sdk` | PHP umbrella package | surface-specific | `composer require sendmux/sdk:^2.0` | [`packages/php/sdk`](packages/php/sdk) |
+| Packagist | `sendmux/core` | Shared PHP helpers | n/a | `composer require sendmux/core:^2.1` | [`packages/php/core`](packages/php/core) |
+| Packagist | `sendmux/sending` | Sending API | `smx_mbx_*` or owner-approved `smx_agent_*` | `composer require sendmux/sending:^2.1` | [`packages/php/sending`](packages/php/sending) |
+| Packagist | `sendmux/mailbox` | Mailbox API | `smx_mbx_*` or `smx_agent_*` | `composer require sendmux/mailbox:^2.1` | [`packages/php/mailbox`](packages/php/mailbox) |
+| Packagist | `sendmux/management` | Management API | `smx_root_*` | `composer require sendmux/management:^2.1` | [`packages/php/management`](packages/php/management) |
+| Packagist | `sendmux/sdk` | PHP umbrella package | surface-specific | `composer require sendmux/sdk:^2.1` | [`packages/php/sdk`](packages/php/sdk) |
 | RubyGems | `sendmux-core` | Shared Ruby helpers | n/a | `gem install sendmux-core` | [`packages/ruby/core`](packages/ruby/core) |
 | RubyGems | `sendmux-sending` | Sending API | `smx_mbx_*` or owner-approved `smx_agent_*` | `gem install sendmux-sending` | [`packages/ruby/sending`](packages/ruby/sending) |
 | RubyGems | `sendmux-mailbox` | Mailbox API | `smx_mbx_*` or `smx_agent_*` | `gem install sendmux-mailbox` | [`packages/ruby/mailbox`](packages/ruby/mailbox) |
@@ -59,9 +59,9 @@ Install only the package for the surface you need.
 ```sh
 npm install @sendmux/sending
 pip install sendmux-sending
-go get sendmux.ai/go@v1.5.0
+go get sendmux.ai/go@v1.6.0
 cargo add sendmux
-composer require sendmux/sending:^2.0
+composer require sendmux/sending:^2.1
 gem install sendmux-sending
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,11 @@
   "require-dev": {
     "phpstan/phpstan": "^2.1",
     "phpunit/phpunit": "^11.5",
-    "sendmux/core": "2.0.0",
-    "sendmux/mailbox": "2.0.0",
-    "sendmux/management": "2.0.0",
-    "sendmux/sdk": "2.0.0",
-    "sendmux/sending": "2.0.0",
+    "sendmux/core": "2.1.0",
+    "sendmux/mailbox": "2.1.0",
+    "sendmux/management": "2.1.0",
+    "sendmux/sdk": "2.1.0",
+    "sendmux/sending": "2.1.0",
     "squizlabs/php_codesniffer": "^3.11"
   },
   "autoload-dev": {
@@ -28,7 +28,7 @@
       "options": {
         "symlink": true,
         "versions": {
-          "sendmux/core": "2.0.0"
+          "sendmux/core": "2.1.0"
         }
       }
     },
@@ -38,7 +38,7 @@
       "options": {
         "symlink": true,
         "versions": {
-          "sendmux/sending": "2.0.0"
+          "sendmux/sending": "2.1.0"
         }
       }
     },
@@ -48,7 +48,7 @@
       "options": {
         "symlink": true,
         "versions": {
-          "sendmux/mailbox": "2.0.0"
+          "sendmux/mailbox": "2.1.0"
         }
       }
     },
@@ -58,7 +58,7 @@
       "options": {
         "symlink": true,
         "versions": {
-          "sendmux/management": "2.0.0"
+          "sendmux/management": "2.1.0"
         }
       }
     },
@@ -68,7 +68,7 @@
       "options": {
         "symlink": true,
         "versions": {
-          "sendmux/sdk": "2.0.0"
+          "sendmux/sdk": "2.1.0"
         }
       }
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7767c935ea35f66f3af97b0c0d405a77",
+    "content-hash": "578d216e1618ce97ede6d06bd63ff587",
     "packages": [],
     "packages-dev": [
         {
@@ -2283,11 +2283,11 @@
         },
         {
             "name": "sendmux/core",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "dist": {
                 "type": "path",
                 "url": "packages/php/core",
-                "reference": "65dd95fb2f4b1845013d1244503f5a04479e0667"
+                "reference": "6fb36d2618b6a7fe26cdb3a5edf5471d4bc7562a"
             },
             "require": {
                 "guzzlehttp/guzzle": "^7.10",
@@ -2311,11 +2311,11 @@
         },
         {
             "name": "sendmux/mailbox",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "dist": {
                 "type": "path",
                 "url": "packages/php/mailbox",
-                "reference": "453bdcfd29807ec2e6ee08d9fc7e2cba811149f8"
+                "reference": "5eb6a26e0f177f66df310a1b32d93b2f78f51c31"
             },
             "require": {
                 "ext-curl": "*",
@@ -2324,7 +2324,7 @@
                 "guzzlehttp/guzzle": "^7.10",
                 "guzzlehttp/psr7": "^2.7",
                 "php": "^8.2",
-                "sendmux/core": "^2.0"
+                "sendmux/core": "^2.1"
             },
             "type": "library",
             "autoload": {
@@ -2343,11 +2343,11 @@
         },
         {
             "name": "sendmux/management",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "dist": {
                 "type": "path",
                 "url": "packages/php/management",
-                "reference": "1d79fffad82e9c8555698819beb53a659ab1aac8"
+                "reference": "e2ba945d34290d8474b527b338ae423243c2acc7"
             },
             "require": {
                 "ext-curl": "*",
@@ -2356,7 +2356,7 @@
                 "guzzlehttp/guzzle": "^7.10",
                 "guzzlehttp/psr7": "^2.7",
                 "php": "^8.2",
-                "sendmux/core": "^2.0"
+                "sendmux/core": "^2.1"
             },
             "type": "library",
             "autoload": {
@@ -2375,18 +2375,18 @@
         },
         {
             "name": "sendmux/sdk",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "dist": {
                 "type": "path",
                 "url": "packages/php/sdk",
-                "reference": "35a74ac8fe3739799b8fad01fa16748da8ff58a6"
+                "reference": "b06727aff6edf0e616f98da0829c6e87428986de"
             },
             "require": {
                 "php": "^8.2",
-                "sendmux/core": "^2.0",
-                "sendmux/mailbox": "^2.0",
-                "sendmux/management": "^2.0",
-                "sendmux/sending": "^2.0"
+                "sendmux/core": "^2.1",
+                "sendmux/mailbox": "^2.1",
+                "sendmux/management": "^2.1",
+                "sendmux/sending": "^2.1"
             },
             "type": "library",
             "autoload": {
@@ -2405,11 +2405,11 @@
         },
         {
             "name": "sendmux/sending",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "dist": {
                 "type": "path",
                 "url": "packages/php/sending",
-                "reference": "65fb6c1f0f50f94e9863cf809c16abd18840189e"
+                "reference": "5ce1526cf617bb88d33f2ed18893a7aa7cc4709a"
             },
             "require": {
                 "ext-curl": "*",
@@ -2418,7 +2418,7 @@
                 "guzzlehttp/guzzle": "^7.10",
                 "guzzlehttp/psr7": "^2.7",
                 "php": "^8.2",
-                "sendmux/core": "^2.0"
+                "sendmux/core": "^2.1"
             },
             "type": "library",
             "autoload": {

--- a/go/mailbox/oas_client_gen.go
+++ b/go/mailbox/oas_client_gen.go
@@ -8356,23 +8356,6 @@ func (c *Client) sendMailboxStreamEvents(ctx context.Context, params MailboxStre
 	stage = "EncodeQueryParams"
 	q := uri.NewQueryEncoder()
 	{
-		// Encode "mailbox_id" parameter.
-		cfg := uri.QueryParameterEncodingConfig{
-			Name:    "mailbox_id",
-			Style:   uri.QueryStyleForm,
-			Explode: true,
-		}
-
-		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
-			if val, ok := params.MailboxID.Get(); ok {
-				return e.EncodeValue(conv.StringToString(val))
-			}
-			return nil
-		}); err != nil {
-			return res, errors.Wrap(err, "encode query")
-		}
-	}
-	{
 		// Encode "event_types" parameter.
 		cfg := uri.QueryParameterEncodingConfig{
 			Name:    "event_types",
@@ -8434,6 +8417,23 @@ func (c *Client) sendMailboxStreamEvents(ctx context.Context, params MailboxStre
 		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
 			if val, ok := params.CloseAfter.Get(); ok {
 				return e.EncodeValue(conv.IntToString(val))
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "mailbox_id" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "mailbox_id",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if val, ok := params.MailboxID.Get(); ok {
+				return e.EncodeValue(conv.StringToString(val))
 			}
 			return nil
 		}); err != nil {

--- a/go/mailbox/oas_handlers_gen.go
+++ b/go/mailbox/oas_handlers_gen.go
@@ -7787,10 +7787,6 @@ func (s *Server) handleMailboxStreamEventsRequest(args [0]string, argsEscaped bo
 			Body:             nil,
 			Params: middleware.Parameters{
 				{
-					Name: "mailbox_id",
-					In:   "query",
-				}: params.MailboxID,
-				{
 					Name: "event_types",
 					In:   "query",
 				}: params.EventTypes,
@@ -7810,6 +7806,10 @@ func (s *Server) handleMailboxStreamEventsRequest(args [0]string, argsEscaped bo
 					Name: "Last-Event-ID",
 					In:   "header",
 				}: params.HeaderLastEventID,
+				{
+					Name: "mailbox_id",
+					In:   "query",
+				}: params.MailboxID,
 			},
 			Raw: r,
 		}

--- a/go/mailbox/oas_parameters_gen.go
+++ b/go/mailbox/oas_parameters_gen.go
@@ -13082,24 +13082,15 @@ func decodeMailboxSendMessageParams(args [0]string, argsEscaped bool, r *http.Re
 
 // MailboxStreamEventsParams is parameters of mailboxStreamEvents operation.
 type MailboxStreamEventsParams struct {
-	MailboxID         OptString
 	EventTypes        OptString
 	QueryLastEventID  OptString
 	Ping              OptInt
 	CloseAfter        OptInt
 	HeaderLastEventID OptString
+	MailboxID         OptString
 }
 
 func unpackMailboxStreamEventsParams(packed middleware.Parameters) (params MailboxStreamEventsParams) {
-	{
-		key := middleware.ParameterKey{
-			Name: "mailbox_id",
-			In:   "query",
-		}
-		if v, ok := packed[key]; ok {
-			params.MailboxID = v.(OptString)
-		}
-	}
 	{
 		key := middleware.ParameterKey{
 			Name: "event_types",
@@ -13145,53 +13136,21 @@ func unpackMailboxStreamEventsParams(packed middleware.Parameters) (params Mailb
 			params.HeaderLastEventID = v.(OptString)
 		}
 	}
+	{
+		key := middleware.ParameterKey{
+			Name: "mailbox_id",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.MailboxID = v.(OptString)
+		}
+	}
 	return params
 }
 
 func decodeMailboxStreamEventsParams(args [0]string, argsEscaped bool, r *http.Request) (params MailboxStreamEventsParams, _ error) {
 	q := uri.NewQueryDecoder(r.URL.Query())
 	h := uri.NewHeaderDecoder(r.Header)
-	// Decode query: mailbox_id.
-	if err := func() error {
-		cfg := uri.QueryParameterDecodingConfig{
-			Name:    "mailbox_id",
-			Style:   uri.QueryStyleForm,
-			Explode: true,
-		}
-
-		if err := q.HasParam(cfg); err == nil {
-			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
-				var paramsDotMailboxIDVal string
-				if err := func() error {
-					val, err := d.DecodeValue()
-					if err != nil {
-						return err
-					}
-
-					c, err := conv.ToString(val)
-					if err != nil {
-						return err
-					}
-
-					paramsDotMailboxIDVal = c
-					return nil
-				}(); err != nil {
-					return err
-				}
-				params.MailboxID.SetTo(paramsDotMailboxIDVal)
-				return nil
-			}); err != nil {
-				return err
-			}
-		}
-		return nil
-	}(); err != nil {
-		return params, &ogenerrors.DecodeParamError{
-			Name: "mailbox_id",
-			In:   "query",
-			Err:  err,
-		}
-	}
 	// Decode query: event_types.
 	if err := func() error {
 		cfg := uri.QueryParameterDecodingConfig{
@@ -13440,6 +13399,47 @@ func decodeMailboxStreamEventsParams(args [0]string, argsEscaped bool, r *http.R
 		return params, &ogenerrors.DecodeParamError{
 			Name: "Last-Event-ID",
 			In:   "header",
+			Err:  err,
+		}
+	}
+	// Decode query: mailbox_id.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "mailbox_id",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				var paramsDotMailboxIDVal string
+				if err := func() error {
+					val, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(val)
+					if err != nil {
+						return err
+					}
+
+					paramsDotMailboxIDVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.MailboxID.SetTo(paramsDotMailboxIDVal)
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "mailbox_id",
+			In:   "query",
 			Err:  err,
 		}
 	}

--- a/packages/php/core/CHANGELOG.md
+++ b/packages/php/core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.1.0 (2026-09-11)
+
+- Add REST OAuth access tokens and callable token providers with validation before authenticated requests.
+- Respect explicit non-retryable errors and elapsed retry budgets while preserving the final response and retry metadata.
+
 ## 2.0.0 (2026-09-08)
 
 - Add a Sending credential surface and support scoped agent tokens for Mailbox and owner-approved Sending access.

--- a/packages/php/core/README.md
+++ b/packages/php/core/README.md
@@ -16,7 +16,7 @@ Read the PHP SDK guide at [sendmux.ai/docs/sdks/php](https://sendmux.ai/docs/sdk
 ## Installation
 
 ```bash
-composer require sendmux/core:^2.0
+composer require sendmux/core:^2.1
 ```
 
 Upgrading from 1.x? Read the [PHP 2.0 migration guide](https://github.com/Sendmux/sendmux-sdk/blob/main/packages/php/UPGRADING.md) before changing your Composer constraint.

--- a/packages/php/mailbox/CHANGELOG.md
+++ b/packages/php/mailbox/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add `WithAccessToken` factories for REST OAuth tokens and callable providers.
 - Require core 2.1 for OAuth authentication and retry handling.
+- Preserve the published positional arguments for all five mailbox streaming methods.
 
 ## 2.0.0 (2026-09-08)
 

--- a/packages/php/mailbox/CHANGELOG.md
+++ b/packages/php/mailbox/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.1.0 (2026-09-11)
+
+- Add `WithAccessToken` factories for REST OAuth tokens and callable providers.
+- Require core 2.1 for OAuth authentication and retry handling.
+
 ## 2.0.0 (2026-09-08)
 
 - Add `mailboxGetConnection()` without a target mailbox selector.

--- a/packages/php/mailbox/README.md
+++ b/packages/php/mailbox/README.md
@@ -17,7 +17,7 @@ Read the PHP SDK guide at [sendmux.ai/docs/sdks/php](https://sendmux.ai/docs/sdk
 ## Installation
 
 ```bash
-composer require sendmux/mailbox:^2.0
+composer require sendmux/mailbox:^2.1
 ```
 
 Upgrading from 1.x? Read the [PHP 2.0 migration guide](https://github.com/Sendmux/sendmux-sdk/blob/main/packages/php/UPGRADING.md) before changing your Composer constraint.

--- a/packages/php/mailbox/composer.json
+++ b/packages/php/mailbox/composer.json
@@ -10,7 +10,7 @@
     "ext-mbstring": "*",
     "guzzlehttp/guzzle": "^7.10",
     "guzzlehttp/psr7": "^2.7",
-    "sendmux/core": "^2.0"
+    "sendmux/core": "^2.1"
   },
   "autoload": {
     "psr-4": {

--- a/packages/php/mailbox/src/Api/MailboxAPIApi.php
+++ b/packages/php/mailbox/src/Api/MailboxAPIApi.php
@@ -16923,12 +16923,12 @@ class MailboxAPIApi
      *
      * Stream mailbox events
      *
-     * @param  string|null $mailbox_id mailbox_id (optional)
      * @param  string|null $event_types event_types (optional)
      * @param  string|null $last_event_id last_event_id (optional)
      * @param  int|null $ping ping (optional)
      * @param  int|null $close_after close_after (optional)
      * @param  string|null $last_event_id2 last_event_id2 (optional)
+     * @param  string|null $mailbox_id mailbox_id (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['mailboxStreamEvents'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -16936,21 +16936,21 @@ class MailboxAPIApi
      * @return \Sendmux\Mailbox\Model\MailboxRealtimeEvent|\Sendmux\Mailbox\Model\ApiError
      */
     public function mailboxStreamEvents(
-        ?string $mailbox_id = null,
         ?string $event_types = null,
         ?string $last_event_id = null,
         ?int $ping = null,
         ?int $close_after = null,
         ?string $last_event_id2 = null,
+        ?string $mailbox_id = null,
         string $contentType = self::contentTypes['mailboxStreamEvents'][0]
     ): \Sendmux\Mailbox\Model\MailboxRealtimeEvent|\Sendmux\Mailbox\Model\ApiError {
         list($response) = $this->mailboxStreamEventsWithHttpInfo(
-            $mailbox_id,
             $event_types,
             $last_event_id,
             $ping,
             $close_after,
             $last_event_id2,
+            $mailbox_id,
             $contentType
         );
         return $response;
@@ -16961,12 +16961,12 @@ class MailboxAPIApi
      *
      * Stream mailbox events
      *
-     * @param  string|null $mailbox_id mailbox_id (optional)
      * @param  string|null $event_types event_types (optional)
      * @param  string|null $last_event_id last_event_id (optional)
      * @param  int|null $ping ping (optional)
      * @param  int|null $close_after close_after (optional)
      * @param  string|null $last_event_id2 last_event_id2 (optional)
+     * @param  string|null $mailbox_id mailbox_id (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['mailboxStreamEvents'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
@@ -16974,21 +16974,21 @@ class MailboxAPIApi
      * @return array of \Sendmux\Mailbox\Model\MailboxRealtimeEvent|\Sendmux\Mailbox\Model\ApiError|\Sendmux\Mailbox\Model\ApiError|\Sendmux\Mailbox\Model\ApiError|\Sendmux\Mailbox\Model\ApiError|\Sendmux\Mailbox\Model\ApiError, HTTP status code, HTTP response headers (array of strings)
      */
     public function mailboxStreamEventsWithHttpInfo(
-        ?string $mailbox_id = null,
         ?string $event_types = null,
         ?string $last_event_id = null,
         ?int $ping = null,
         ?int $close_after = null,
         ?string $last_event_id2 = null,
+        ?string $mailbox_id = null,
         string $contentType = self::contentTypes['mailboxStreamEvents'][0]
     ): array {
         $request = $this->mailboxStreamEventsRequest(
-            $mailbox_id,
             $event_types,
             $last_event_id,
             $ping,
             $close_after,
             $last_event_id2,
+            $mailbox_id,
             $contentType
         );
 
@@ -17133,33 +17133,33 @@ class MailboxAPIApi
      *
      * Stream mailbox events
      *
-     * @param  string|null $mailbox_id mailbox_id (optional)
      * @param  string|null $event_types event_types (optional)
      * @param  string|null $last_event_id last_event_id (optional)
      * @param  int|null $ping ping (optional)
      * @param  int|null $close_after close_after (optional)
      * @param  string|null $last_event_id2 last_event_id2 (optional)
+     * @param  string|null $mailbox_id mailbox_id (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['mailboxStreamEvents'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
      * @return PromiseInterface
      */
     public function mailboxStreamEventsAsync(
-        ?string $mailbox_id = null,
         ?string $event_types = null,
         ?string $last_event_id = null,
         ?int $ping = null,
         ?int $close_after = null,
         ?string $last_event_id2 = null,
+        ?string $mailbox_id = null,
         string $contentType = self::contentTypes['mailboxStreamEvents'][0]
     ): PromiseInterface {
         return $this->mailboxStreamEventsAsyncWithHttpInfo(
-            $mailbox_id,
             $event_types,
             $last_event_id,
             $ping,
             $close_after,
             $last_event_id2,
+            $mailbox_id,
             $contentType
         )
             ->then(
@@ -17174,34 +17174,34 @@ class MailboxAPIApi
      *
      * Stream mailbox events
      *
-     * @param  string|null $mailbox_id mailbox_id (optional)
      * @param  string|null $event_types event_types (optional)
      * @param  string|null $last_event_id last_event_id (optional)
      * @param  int|null $ping ping (optional)
      * @param  int|null $close_after close_after (optional)
      * @param  string|null $last_event_id2 last_event_id2 (optional)
+     * @param  string|null $mailbox_id mailbox_id (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['mailboxStreamEvents'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
      * @return PromiseInterface
      */
     public function mailboxStreamEventsAsyncWithHttpInfo(
-        ?string $mailbox_id = null,
         ?string $event_types = null,
         ?string $last_event_id = null,
         ?int $ping = null,
         ?int $close_after = null,
         ?string $last_event_id2 = null,
+        ?string $mailbox_id = null,
         string $contentType = self::contentTypes['mailboxStreamEvents'][0]
     ): PromiseInterface {
         $returnType = '\Sendmux\Mailbox\Model\MailboxRealtimeEvent';
         $request = $this->mailboxStreamEventsRequest(
-            $mailbox_id,
             $event_types,
             $last_event_id,
             $ping,
             $close_after,
             $last_event_id2,
+            $mailbox_id,
             $contentType
         );
 
@@ -17247,27 +17247,26 @@ class MailboxAPIApi
     /**
      * Create request for operation 'mailboxStreamEvents'
      *
-     * @param  string|null $mailbox_id mailbox_id (optional)
      * @param  string|null $event_types event_types (optional)
      * @param  string|null $last_event_id last_event_id (optional)
      * @param  int|null $ping ping (optional)
      * @param  int|null $close_after close_after (optional)
      * @param  string|null $last_event_id2 last_event_id2 (optional)
+     * @param  string|null $mailbox_id mailbox_id (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['mailboxStreamEvents'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function mailboxStreamEventsRequest(
-        ?string $mailbox_id = null,
         ?string $event_types = null,
         ?string $last_event_id = null,
         ?int $ping = null,
         ?int $close_after = null,
         ?string $last_event_id2 = null,
+        ?string $mailbox_id = null,
         string $contentType = self::contentTypes['mailboxStreamEvents'][0]
     ): Request {
-
 
 
 
@@ -17287,6 +17286,7 @@ class MailboxAPIApi
 
 
 
+
         $resourcePath = '/mailbox/events';
         $formParams = [];
         $queryParams = [];
@@ -17294,15 +17294,6 @@ class MailboxAPIApi
         $httpBody = '';
         $multipart = false;
 
-        // query params
-        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
-            $mailbox_id,
-            'mailbox_id', // param base name
-            'string', // openApiType
-            'form', // style
-            true, // explode
-            false // required
-        ) ?? []);
         // query params
         $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
             $event_types,
@@ -17335,6 +17326,15 @@ class MailboxAPIApi
             $close_after,
             'close_after', // param base name
             'integer', // openApiType
+            'form', // style
+            true, // explode
+            false // required
+        ) ?? []);
+        // query params
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $mailbox_id,
+            'mailbox_id', // param base name
+            'string', // openApiType
             'form', // style
             true, // explode
             false // required

--- a/packages/php/mailbox/src/Configuration.php
+++ b/packages/php/mailbox/src/Configuration.php
@@ -100,7 +100,7 @@ class Configuration
      *
      * @var string
      */
-    protected string $userAgent = 'OpenAPI-Generator/2.0.0/PHP';
+    protected string $userAgent = 'OpenAPI-Generator/2.1.0/PHP';
 
     /**
      * Debug switch (default set to false)
@@ -429,7 +429,7 @@ class Configuration
         $report .= '    OS: ' . php_uname() . PHP_EOL;
         $report .= '    PHP Version: ' . PHP_VERSION . PHP_EOL;
         $report .= '    The version of the OpenAPI document: 1.0.0' . PHP_EOL;
-        $report .= '    SDK Package Version: 2.0.0' . PHP_EOL;
+        $report .= '    SDK Package Version: 2.1.0' . PHP_EOL;
         $report .= '    Temp Folder Path: ' . self::getDefaultConfiguration()->getTempFolderPath() . PHP_EOL;
 
         return $report;

--- a/packages/php/management/CHANGELOG.md
+++ b/packages/php/management/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.1.0 (2026-09-11)
+
+- Add `WithAccessToken` factories for REST OAuth tokens and callable providers.
+- Require core 2.1 for OAuth authentication and retry handling.
+
 ## 2.0.0 (2026-09-08)
 
 - Add `managementGetConnection()` and the connection client factory.

--- a/packages/php/management/README.md
+++ b/packages/php/management/README.md
@@ -17,7 +17,7 @@ Read the PHP SDK guide at [sendmux.ai/docs/sdks/php](https://sendmux.ai/docs/sdk
 ## Installation
 
 ```bash
-composer require sendmux/management:^2.0
+composer require sendmux/management:^2.1
 ```
 
 Upgrading from 1.x? Read the [PHP 2.0 migration guide](https://github.com/Sendmux/sendmux-sdk/blob/main/packages/php/UPGRADING.md) before changing your Composer constraint.

--- a/packages/php/management/composer.json
+++ b/packages/php/management/composer.json
@@ -10,7 +10,7 @@
     "ext-mbstring": "*",
     "guzzlehttp/guzzle": "^7.10",
     "guzzlehttp/psr7": "^2.7",
-    "sendmux/core": "^2.0"
+    "sendmux/core": "^2.1"
   },
   "autoload": {
     "psr-4": {

--- a/packages/php/management/src/Configuration.php
+++ b/packages/php/management/src/Configuration.php
@@ -100,7 +100,7 @@ class Configuration
      *
      * @var string
      */
-    protected string $userAgent = 'OpenAPI-Generator/2.0.0/PHP';
+    protected string $userAgent = 'OpenAPI-Generator/2.1.0/PHP';
 
     /**
      * Debug switch (default set to false)
@@ -429,7 +429,7 @@ class Configuration
         $report .= '    OS: ' . php_uname() . PHP_EOL;
         $report .= '    PHP Version: ' . PHP_VERSION . PHP_EOL;
         $report .= '    The version of the OpenAPI document: 1.0.0' . PHP_EOL;
-        $report .= '    SDK Package Version: 2.0.0' . PHP_EOL;
+        $report .= '    SDK Package Version: 2.1.0' . PHP_EOL;
         $report .= '    Temp Folder Path: ' . self::getDefaultConfiguration()->getTempFolderPath() . PHP_EOL;
 
         return $report;

--- a/packages/php/sdk/CHANGELOG.md
+++ b/packages/php/sdk/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.1.0 (2026-09-11)
+
+- Require the OAuth-capable 2.1 core, Sending, Mailbox and Management packages.
+- Update the public SDK version constant to 2.1.0.
+
 ## 2.0.0 (2026-09-08)
 
 - Require the connection-capable 2.0 core, Sending, Mailbox and Management packages.

--- a/packages/php/sdk/README.md
+++ b/packages/php/sdk/README.md
@@ -17,7 +17,7 @@ Read the PHP SDK guide at [sendmux.ai/docs/sdks/php](https://sendmux.ai/docs/sdk
 ## Installation
 
 ```bash
-composer require sendmux/sdk:^2.0
+composer require sendmux/sdk:^2.1
 ```
 
 Upgrading from 1.x? Read the [PHP 2.0 migration guide](https://github.com/Sendmux/sendmux-sdk/blob/main/packages/php/UPGRADING.md) before changing your Composer constraint.

--- a/packages/php/sdk/composer.json
+++ b/packages/php/sdk/composer.json
@@ -5,10 +5,10 @@
   "license": "MIT",
   "require": {
     "php": "^8.2",
-    "sendmux/core": "^2.0",
-    "sendmux/mailbox": "^2.0",
-    "sendmux/management": "^2.0",
-    "sendmux/sending": "^2.0"
+    "sendmux/core": "^2.1",
+    "sendmux/mailbox": "^2.1",
+    "sendmux/management": "^2.1",
+    "sendmux/sending": "^2.1"
   },
   "autoload": {
     "psr-4": {

--- a/packages/php/sdk/src/Sdk.php
+++ b/packages/php/sdk/src/Sdk.php
@@ -6,5 +6,5 @@ namespace Sendmux\Sdk;
 
 final class Sdk
 {
-    public const VERSION = '2.0.0';
+    public const VERSION = '2.1.0';
 }

--- a/packages/php/sending/CHANGELOG.md
+++ b/packages/php/sending/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.1.0 (2026-09-11)
+
+- Add `WithAccessToken` factories for REST OAuth tokens and callable providers.
+- Require core 2.1 for OAuth authentication and retry handling.
+
 ## 2.0.0 (2026-09-08)
 
 - Add `sendingGetConnection()` for side-effect-free connection checks.

--- a/packages/php/sending/README.md
+++ b/packages/php/sending/README.md
@@ -17,7 +17,7 @@ Read the PHP SDK guide at [sendmux.ai/docs/sdks/php](https://sendmux.ai/docs/sdk
 ## Installation
 
 ```bash
-composer require sendmux/sending:^2.0
+composer require sendmux/sending:^2.1
 ```
 
 Upgrading from 1.x? Read the [PHP 2.0 migration guide](https://github.com/Sendmux/sendmux-sdk/blob/main/packages/php/UPGRADING.md) before changing your Composer constraint.

--- a/packages/php/sending/composer.json
+++ b/packages/php/sending/composer.json
@@ -10,7 +10,7 @@
     "ext-mbstring": "*",
     "guzzlehttp/guzzle": "^7.10",
     "guzzlehttp/psr7": "^2.7",
-    "sendmux/core": "^2.0"
+    "sendmux/core": "^2.1"
   },
   "autoload": {
     "psr-4": {

--- a/packages/php/sending/src/Configuration.php
+++ b/packages/php/sending/src/Configuration.php
@@ -100,7 +100,7 @@ class Configuration
      *
      * @var string
      */
-    protected string $userAgent = 'OpenAPI-Generator/2.0.0/PHP';
+    protected string $userAgent = 'OpenAPI-Generator/2.1.0/PHP';
 
     /**
      * Debug switch (default set to false)
@@ -429,7 +429,7 @@ class Configuration
         $report .= '    OS: ' . php_uname() . PHP_EOL;
         $report .= '    PHP Version: ' . PHP_VERSION . PHP_EOL;
         $report .= '    The version of the OpenAPI document: 1.0.0' . PHP_EOL;
-        $report .= '    SDK Package Version: 2.0.0' . PHP_EOL;
+        $report .= '    SDK Package Version: 2.1.0' . PHP_EOL;
         $report .= '    Temp Folder Path: ' . self::getDefaultConfiguration()->getTempFolderPath() . PHP_EOL;
 
         return $report;

--- a/packages/php/tests/MailboxStreamArgumentsTest.php
+++ b/packages/php/tests/MailboxStreamArgumentsTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sendmux\Tests;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Sendmux\Mailbox\Api\MailboxAPIApi;
+use Sendmux\Mailbox\ApiException;
+
+final class MailboxStreamArgumentsTest extends TestCase
+{
+    /** @return iterable<string, array{string, string|null}> */
+    public static function streamMethods(): iterable
+    {
+        foreach (['', 'WithHttpInfo', 'Async', 'AsyncWithHttpInfo', 'Request'] as $suffix) {
+            yield 'selected mailbox' . $suffix => ['mailboxStreamEvents' . $suffix, 'mailbox_123'];
+            yield 'implicit mailbox' . $suffix => ['mailboxStreamEvents' . $suffix, null];
+        }
+    }
+
+    #[DataProvider('streamMethods')]
+    public function testPublishedPositionalArgumentsReachRequest(string $method, ?string $mailboxId): void
+    {
+        $history = [];
+        $handler = HandlerStack::create(new MockHandler([new Response(401)]));
+        $handler->push(Middleware::history($history));
+        $api = new MailboxAPIApi(new Client(['handler' => $handler]));
+        $result = null;
+
+        try {
+            $result = $api->$method('message.received', 'resume-query', 15, 60, 'resume-header', $mailboxId);
+            if ($result instanceof PromiseInterface) {
+                $result->wait();
+            }
+        } catch (ApiException $error) {
+            self::assertSame(401, $error->getCode());
+        }
+
+        if ($result instanceof RequestInterface) {
+            $request = $result;
+        } else {
+            self::assertIsArray($history);
+            self::assertCount(1, $history);
+            $transaction = $history[0];
+            self::assertIsArray($transaction);
+            $request = $transaction['request'];
+            self::assertInstanceOf(RequestInterface::class, $request);
+        }
+
+        parse_str($request->getUri()->getQuery(), $query);
+        self::assertSame('GET', $request->getMethod());
+        self::assertSame('message.received', $query['event_types'] ?? null);
+        self::assertSame('resume-query', $query['last_event_id'] ?? null);
+        self::assertSame('15', $query['ping'] ?? null);
+        self::assertSame('60', $query['close_after'] ?? null);
+        self::assertSame($mailboxId, $query['mailbox_id'] ?? null);
+        self::assertSame('resume-header', $request->getHeaderLine('Last-Event-ID'));
+    }
+}

--- a/packages/python/mailbox/sendmux_mailbox/api/mailbox_api_api.py
+++ b/packages/python/mailbox/sendmux_mailbox/api/mailbox_api_api.py
@@ -13430,12 +13430,12 @@ class MailboxAPIApi:
     @validate_call
     def mailbox_stream_events(
         self,
-        mailbox_id: Optional[StrictStr] = None,
         event_types: Optional[StrictStr] = None,
         last_event_id: Optional[StrictStr] = None,
         ping: Optional[Annotated[int, Field(le=300, strict=True, ge=10)]] = None,
         close_after: Optional[Annotated[int, Field(le=3600, strict=True, ge=30)]] = None,
         last_event_id2: Optional[StrictStr] = None,
+        mailbox_id: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -13453,8 +13453,6 @@ class MailboxAPIApi:
 
         Streams bounded rich mailbox events for connected clients. Each received-message event includes subject, participants, preview, attachment metadata, and a capped body snapshot; use the message endpoints for full content or attachment bytes.
 
-        :param mailbox_id:
-        :type mailbox_id: str
         :param event_types:
         :type event_types: str
         :param last_event_id:
@@ -13465,6 +13463,8 @@ class MailboxAPIApi:
         :type close_after: int
         :param last_event_id2:
         :type last_event_id2: str
+        :param mailbox_id:
+        :type mailbox_id: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -13488,12 +13488,12 @@ class MailboxAPIApi:
         """ # noqa: E501
 
         _param = self._mailbox_stream_events_serialize(
-            mailbox_id=mailbox_id,
             event_types=event_types,
             last_event_id=last_event_id,
             ping=ping,
             close_after=close_after,
             last_event_id2=last_event_id2,
+            mailbox_id=mailbox_id,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -13522,12 +13522,12 @@ class MailboxAPIApi:
     @validate_call
     def mailbox_stream_events_with_http_info(
         self,
-        mailbox_id: Optional[StrictStr] = None,
         event_types: Optional[StrictStr] = None,
         last_event_id: Optional[StrictStr] = None,
         ping: Optional[Annotated[int, Field(le=300, strict=True, ge=10)]] = None,
         close_after: Optional[Annotated[int, Field(le=3600, strict=True, ge=30)]] = None,
         last_event_id2: Optional[StrictStr] = None,
+        mailbox_id: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -13545,8 +13545,6 @@ class MailboxAPIApi:
 
         Streams bounded rich mailbox events for connected clients. Each received-message event includes subject, participants, preview, attachment metadata, and a capped body snapshot; use the message endpoints for full content or attachment bytes.
 
-        :param mailbox_id:
-        :type mailbox_id: str
         :param event_types:
         :type event_types: str
         :param last_event_id:
@@ -13557,6 +13555,8 @@ class MailboxAPIApi:
         :type close_after: int
         :param last_event_id2:
         :type last_event_id2: str
+        :param mailbox_id:
+        :type mailbox_id: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -13580,12 +13580,12 @@ class MailboxAPIApi:
         """ # noqa: E501
 
         _param = self._mailbox_stream_events_serialize(
-            mailbox_id=mailbox_id,
             event_types=event_types,
             last_event_id=last_event_id,
             ping=ping,
             close_after=close_after,
             last_event_id2=last_event_id2,
+            mailbox_id=mailbox_id,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -13614,12 +13614,12 @@ class MailboxAPIApi:
     @validate_call
     def mailbox_stream_events_without_preload_content(
         self,
-        mailbox_id: Optional[StrictStr] = None,
         event_types: Optional[StrictStr] = None,
         last_event_id: Optional[StrictStr] = None,
         ping: Optional[Annotated[int, Field(le=300, strict=True, ge=10)]] = None,
         close_after: Optional[Annotated[int, Field(le=3600, strict=True, ge=30)]] = None,
         last_event_id2: Optional[StrictStr] = None,
+        mailbox_id: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -13637,8 +13637,6 @@ class MailboxAPIApi:
 
         Streams bounded rich mailbox events for connected clients. Each received-message event includes subject, participants, preview, attachment metadata, and a capped body snapshot; use the message endpoints for full content or attachment bytes.
 
-        :param mailbox_id:
-        :type mailbox_id: str
         :param event_types:
         :type event_types: str
         :param last_event_id:
@@ -13649,6 +13647,8 @@ class MailboxAPIApi:
         :type close_after: int
         :param last_event_id2:
         :type last_event_id2: str
+        :param mailbox_id:
+        :type mailbox_id: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -13672,12 +13672,12 @@ class MailboxAPIApi:
         """ # noqa: E501
 
         _param = self._mailbox_stream_events_serialize(
-            mailbox_id=mailbox_id,
             event_types=event_types,
             last_event_id=last_event_id,
             ping=ping,
             close_after=close_after,
             last_event_id2=last_event_id2,
+            mailbox_id=mailbox_id,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -13701,12 +13701,12 @@ class MailboxAPIApi:
 
     def _mailbox_stream_events_serialize(
         self,
-        mailbox_id,
         event_types,
         last_event_id,
         ping,
         close_after,
         last_event_id2,
+        mailbox_id,
         _request_auth,
         _content_type,
         _headers,
@@ -13729,10 +13729,6 @@ class MailboxAPIApi:
 
         # process the path parameters
         # process the query parameters
-        if mailbox_id is not None:
-
-            _query_params.append(('mailbox_id', mailbox_id))
-
         if event_types is not None:
 
             _query_params.append(('event_types', event_types))
@@ -13748,6 +13744,10 @@ class MailboxAPIApi:
         if close_after is not None:
 
             _query_params.append(('close_after', close_after))
+
+        if mailbox_id is not None:
+
+            _query_params.append(('mailbox_id', mailbox_id))
 
         # process the header parameters
         if last_event_id2 is not None:

--- a/packages/python/tests/test_mailbox_stream_arguments.py
+++ b/packages/python/tests/test_mailbox_stream_arguments.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
+from typing import Any
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+
+from sendmux_mailbox import MailboxAPIApi, create_mailbox_client
+from sendmux_core import SendmuxApiError
+
+
+@pytest.fixture
+def endpoint() -> Iterator[tuple[str, list[tuple[str, str | None]]]]:
+    requests: list[tuple[str, str | None]] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            requests.append((self.path, self.headers.get("Last-Event-ID")))
+            self.send_response(401)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def log_message(self, format: str, *args: Any) -> None:
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = Thread(target=lambda: server.serve_forever(poll_interval=0.01))
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}/api/v1", requests
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+        assert not thread.is_alive()
+
+
+@pytest.mark.parametrize("method", [
+    "mailbox_stream_events",
+    "mailbox_stream_events_with_http_info",
+    "mailbox_stream_events_without_preload_content",
+])
+@pytest.mark.parametrize("mailbox_id", ["mailbox_123", None])
+def test_published_positional_arguments_reach_request(method: str, mailbox_id: str | None, endpoint: Any) -> None:
+    url, requests = endpoint
+    with create_mailbox_client(api_key="smx_mbx_test", base_url=url) as client:
+        stream = getattr(MailboxAPIApi(client), method)
+        try:
+            response = stream("message.received", "resume-query", 15, 60, "resume-header", mailbox_id)
+            assert response.status == 401
+            response.read()
+            response.release_conn()
+        except SendmuxApiError as error:
+            assert error.status_code == 401
+
+    assert len(requests) == 1
+    path, last_event_id = requests[0]
+    assert urlsplit(path).path == "/api/v1/mailbox/events"
+    query = parse_qs(urlsplit(path).query)
+    assert query["event_types"] == ["message.received"]
+    assert query["last_event_id"] == ["resume-query"]
+    assert query["ping"] == ["15"]
+    assert query["close_after"] == ["60"]
+    assert query.get("mailbox_id") == ([mailbox_id] if mailbox_id is not None else None)
+    assert last_event_id == "resume-header"

--- a/packages/ruby/mailbox/lib/sendmux_mailbox_generated/api/mailbox_api_api.rb
+++ b/packages/ruby/mailbox/lib/sendmux_mailbox_generated/api/mailbox_api_api.rb
@@ -3163,12 +3163,12 @@ module Sendmux::Mailbox::Generated
     # Stream mailbox events
     # Streams bounded rich mailbox events for connected clients. Each received-message event includes subject, participants, preview, attachment metadata, and a capped body snapshot; use the message endpoints for full content or attachment bytes.
     # @param [Hash] opts the optional parameters
-    # @option opts [String] :mailbox_id
     # @option opts [String] :event_types
     # @option opts [String] :last_event_id
     # @option opts [Integer] :ping
     # @option opts [Integer] :close_after
     # @option opts [String] :last_event_id2
+    # @option opts [String] :mailbox_id
     # @return [MailboxRealtimeEvent]
     def mailbox_stream_events(opts = {})
       data, _status_code, _headers = mailbox_stream_events_with_http_info(opts)
@@ -3178,12 +3178,12 @@ module Sendmux::Mailbox::Generated
     # Stream mailbox events
     # Streams bounded rich mailbox events for connected clients. Each received-message event includes subject, participants, preview, attachment metadata, and a capped body snapshot; use the message endpoints for full content or attachment bytes.
     # @param [Hash] opts the optional parameters
-    # @option opts [String] :mailbox_id
     # @option opts [String] :event_types
     # @option opts [String] :last_event_id
     # @option opts [Integer] :ping
     # @option opts [Integer] :close_after
     # @option opts [String] :last_event_id2
+    # @option opts [String] :mailbox_id
     # @return [Array<(MailboxRealtimeEvent, Integer, Hash)>] MailboxRealtimeEvent data, response status code and response headers
     def mailbox_stream_events_with_http_info(opts = {})
       if @api_client.config.debugging
@@ -3210,11 +3210,11 @@ module Sendmux::Mailbox::Generated
 
       # query parameters
       query_params = opts[:query_params] || {}
-      query_params[:'mailbox_id'] = opts[:'mailbox_id'] if !opts[:'mailbox_id'].nil?
       query_params[:'event_types'] = opts[:'event_types'] if !opts[:'event_types'].nil?
       query_params[:'last_event_id'] = opts[:'last_event_id'] if !opts[:'last_event_id'].nil?
       query_params[:'ping'] = opts[:'ping'] if !opts[:'ping'].nil?
       query_params[:'close_after'] = opts[:'close_after'] if !opts[:'close_after'].nil?
+      query_params[:'mailbox_id'] = opts[:'mailbox_id'] if !opts[:'mailbox_id'].nil?
 
       # header parameters
       header_params = opts[:header_params] || {}

--- a/packages/ts/mailbox/src/generated/types.gen.ts
+++ b/packages/ts/mailbox/src/generated/types.gen.ts
@@ -1317,16 +1317,16 @@ export type MailboxStreamEventsData = {
     path?: never;
     query?: {
         /**
-         * Select a granted mailbox when using an OAuth token with multiple mailboxes.
-         */
-        mailbox_id?: string;
-        /**
          * Comma-separated list: message.received, message.received.spam.
          */
         event_types?: string;
         last_event_id?: string;
         ping?: number;
         close_after?: number;
+        /**
+         * Select a granted mailbox when using an OAuth token with multiple mailboxes.
+         */
+        mailbox_id?: string;
     };
     url: '/mailbox/events';
 };

--- a/scripts/check-php-splits.mjs
+++ b/scripts/check-php-splits.mjs
@@ -45,12 +45,12 @@ writeFileSync(
         options: {
           symlink: false,
           versions: {
-            [pkg.composer]: "2.0.0",
+            [pkg.composer]: "2.1.0",
           },
         },
       })),
       require: {
-        "sendmux/sdk": "2.0.0",
+        "sendmux/sdk": "2.1.0",
       },
       config: {
         "sort-packages": true,

--- a/scripts/generate-php.mjs
+++ b/scripts/generate-php.mjs
@@ -71,7 +71,7 @@ for (const surface of surfaces) {
       `composerPackageName=${surface.composerName}`,
       `invokerPackage=${surface.namespace.replaceAll("\\", "\\\\")}`,
       "srcBasePath=src",
-      "artifactVersion=2.0.0",
+      "artifactVersion=2.1.0",
       "hideGenerationTimestamp=true",
       "enumUnknownDefaultCase=true",
       "disallowAdditionalPropertiesIfNotPresent=false",

--- a/scripts/normalize-openapi-for-codegen.mjs
+++ b/scripts/normalize-openapi-for-codegen.mjs
@@ -20,6 +20,7 @@ for (const spec of specs) {
   assertOpenApi31({ document: source, file: inputPath });
 
   const stripped = stripUnevaluatedProperties(source);
+  preserveMailboxStreamParameterOrder(stripped);
   const openApi31Codegen = normalizeOpenApi31Document(stripped);
   const codegenName = spec.replace(/\.json$/, ".codegen.json");
   const oagCodegenName = spec.replace(/\.json$/, ".openapi-generator.codegen.json");
@@ -112,6 +113,24 @@ function stripUnevaluatedProperties(value) {
   }
 
   return next;
+}
+
+function preserveMailboxStreamParameterOrder(document) {
+  const operation = document.paths?.["/mailbox/events"]?.get;
+  if (!operation) {
+    return;
+  }
+
+  const index = operation.parameters.findIndex((parameter) => {
+    return parameter.name === "mailbox_id" && parameter.in === "query";
+  });
+  if (index === -1) {
+    throw new Error("Mailbox streaming is missing its mailbox_id query parameter");
+  }
+
+  // Published positional SDK methods place the mailbox selector after the stream options.
+  const [mailboxId] = operation.parameters.splice(index, 1);
+  operation.parameters.push(mailboxId);
 }
 
 function normalizeOpenApiGeneratorDocument(document) {


### PR DESCRIPTION
Existing positional mailbox streaming calls break when the OAuth OpenAPI snapshot moves `mailbox_id` ahead of the stream options. Preserve the published order in the shared code-generation input and regenerate the affected clients. PHP restores all five method variants; Python restores all three. The HTTP parameters and authentication contract are unchanged.

Prepare the five PHP 2.1.0 packages for the REST OAuth factories already merged into the SDK: synchronize Composer dependency floors and lockfile, generated version strings, install commands and changelogs. The root README also advances six Go install commands to the published 1.6.0 release.

Validation:
- Full `pnpm build` passes, including generator drift, language checks, CLI, MCP and connection adapters; PHP has 47 PHPUnit tests (234 assertions) plus 10 HTTP cases, and Python has 109 passing tests.
- Ten PHP regression cases fail before the ordering fix and pass after it. Six Python cases fail against the hash-verified published 1.5.0 wheel and pass against this source; both cover explicit and omitted mailbox selection through the real public methods.
- Comparison with published pre-OAuth clients finds no remaining argument changes in 312 Python API methods or reordered existing PHP arguments; the only other PHP signature changes append the already-approved OAuth/retry options.
- The live application and Sending OpenAPI specifications match the committed snapshots. No real emails are sent by these checks.

PHP split publication and new client patch releases follow this source change; existing package versions and tags are not overwritten.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PHP 2.1.0 adds REST OAuth access-token support, callable token providers, and pre-authentication validation.
  * Retry handling now preserves final responses and retry metadata when retries are unavailable or time budgets are exhausted.

* **Compatibility**
  * Mailbox event-stream methods consistently place the mailbox ID after other stream arguments across PHP, Python, and Ruby SDKs.

* **Documentation**
  * Installation instructions, package references, and quick-start examples now reflect PHP 2.1 and Go 1.6 releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->